### PR TITLE
Add deslop baseline (overall 86.7, 7 findings)

### DIFF
--- a/.deslop-baseline.json
+++ b/.deslop-baseline.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-04-25T09:26:49Z",
+  "deslop_version": "2.1.0",
+  "scores": {
+    "file_health": 70.0,
+    "test_coverage": 50.0,
+    "secret_detection": 100.0,
+    "todo_debt": 100.0,
+    "dependency_health": 100.0,
+    "structural_quality": 100.0,
+    "overall": 86.7
+  },
+  "findings": [
+    {
+      "detector": "file_health",
+      "severity": "high",
+      "key": "tools/handlers_test.go",
+      "summary": "tools/handlers_test.go (1,016 LOC)"
+    },
+    {
+      "detector": "file_health",
+      "severity": "warning",
+      "key": "internal/gleif/client.go",
+      "summary": "internal/gleif/client.go (706 LOC)"
+    },
+    {
+      "detector": "file_health",
+      "severity": "warning",
+      "key": "internal/gleif/client_test.go",
+      "summary": "internal/gleif/client_test.go (646 LOC)"
+    },
+    {
+      "detector": "file_health",
+      "severity": "warning",
+      "key": "tools/handlers.go",
+      "summary": "tools/handlers.go (590 LOC)"
+    },
+    {
+      "detector": "test_coverage",
+      "severity": "warning",
+      "key": "internal/gleif/cache.go",
+      "summary": "internal/gleif/cache.go has no test file"
+    },
+    {
+      "detector": "test_coverage",
+      "severity": "warning",
+      "key": "internal/gleif/errors.go",
+      "summary": "internal/gleif/errors.go has no test file"
+    },
+    {
+      "detector": "test_coverage",
+      "severity": "warning",
+      "key": "internal/gleif/types.go",
+      "summary": "internal/gleif/types.go has no test file"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Records the current code-health snapshot so the weekly deslop cloud routine can compute regressions. Bootstrapping requirement for the routine wrapper that shipped in claude-code-config PR #6 (commit \`f9f105b\`).

## What's recorded

- **Overall:** 86.7 / 100
- **Detector scores:** file_health 70.0, test_coverage 50.0, secret_detection 100.0, todo_debt 100.0, dependency_health 100.0, structural_quality 100.0
- **Findings (7):** 4 file_health (handlers_test.go is high band at 1,016 LOC, three others are warning band 590-706 LOC) + 3 test_coverage (cache.go, errors.go, types.go in internal/gleif lack test files)

Secret scan is clean. The top-level \`.mcpregistry_github_token\` is gitignored and untracked.

## What this enables

Once merged, deploy a weekly cloud routine via \`/schedule create --cron "0 9 * * 1" --repo olgasafonova/gleif-mcp-server\` with the deslop SKILL.md as the prompt. The routine reads this baseline each Monday and only posts to a labeled GitHub Issue when findings drift.

## Test plan

- [ ] Merge this PR
- [ ] Run \`/schedule create\` with deslop prompt
- [ ] Trigger \`/schedule run <routine-id>\` immediately to smoke-test the Issue creation + state-block protocol
- [ ] Verify a labeled "deslop" Issue appears with correct state JSON in the body

🤖 Generated with [Claude Code](https://claude.com/claude-code)