### PR TITLE
fix(security): refuse all redirects on API client to close SSRF pivot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- API client refuses all redirects via `CheckRedirect` returning `http.ErrUseLastResponse`. The GLEIF API does not redirect under normal operation; without this guard, a misconfigured `BaseURL` or a wiki/proxy returning `Location: http://169.254.169.254/...` would pivot a lookup into a fetch against cloud metadata or other link-local internal services, with the body landing in the agent context. (security)
+
 ## [0.8.0] - 2026-05-03
 
 ### Fixed

--- a/internal/gleif/client.go
+++ b/internal/gleif/client.go
@@ -123,6 +123,19 @@ func NewClient(config Config, logger *slog.Logger) *Client {
 				MaxIdleConnsPerHost: 10,
 				IdleConnTimeout:     90 * time.Second,
 			},
+			// SECURITY: Refuse all redirects. The configured BaseURL
+			// (api.gleif.org by default, operator-overridable) is the only
+			// legitimate target. Without CheckRedirect, Go follows up to 10
+			// 3xx responses; a misconfigured deployment combined with a wiki
+			// or proxy returning Location: http://169.254.169.254/... would
+			// pivot the request to internal IPs (cloud metadata, link-local).
+			// GLEIF's API does not redirect under normal operation, so any
+			// 3xx is either misconfiguration or an SSRF attempt. Returning
+			// http.ErrUseLastResponse short-circuits the redirect and
+			// surfaces the 3xx to the caller as an error.
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 		},
 		baseURL: config.BaseURL,
 		logger:  logger,

--- a/internal/gleif/client_redirect_test.go
+++ b/internal/gleif/client_redirect_test.go
@@ -1,0 +1,94 @@
+package gleif
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestAPIClientRefusesRedirectToInternalIP is the SSRF redirect-chain
+// regression test. Before the fix, the http.Client had no CheckRedirect
+// policy, so Go followed up to 10 redirects with no host allowlist. A
+// misconfigured deployment combined with a wiki/proxy returning
+// `Location: http://169.254.169.254/...` would pivot a GLEIF lookup into
+// a fetch against cloud metadata or other link-local internal services,
+// with the body landing in the agent context via the regular response
+// path.
+//
+// After the fix: CheckRedirect returns http.ErrUseLastResponse, so the
+// 3xx response surfaces to the caller without ever touching the redirect
+// target. This test verifies the attacker server (stand-in for an
+// internal IP) is never hit.
+func TestAPIClientRefusesRedirectToInternalIP(t *testing.T) {
+	var attackerHits int32
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attackerHits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	// Configured "GLEIF" server returns 302 redirecting to the attacker
+	// (stand-in for 169.254.169.254 / metadata service).
+	gleif := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", attacker.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer gleif.Close()
+
+	c := newTestClient(gleif.URL)
+
+	_, err := c.GetLEI(context.Background(), "529900T8BM49AURSDO55")
+	if err == nil {
+		t.Fatal("expected error from 302 (redirect refused), got nil")
+	}
+
+	if hits := atomic.LoadInt32(&attackerHits); hits != 0 {
+		t.Errorf("SSRF regression: attacker server was hit %d times; CheckRedirect should have refused the redirect", hits)
+	}
+
+	// Sanity: error message must not echo the attacker URL (would be HG-2 regression too).
+	if strings.Contains(err.Error(), attacker.URL) {
+		t.Errorf("error message leaks attacker URL: %v", err)
+	}
+}
+
+// TestAPIClientRefusesRedirectChain verifies that a multi-hop redirect chain
+// is also refused at the first hop, not after N hops. Before the fix Go
+// followed up to 10 redirects by default; after the fix, the first 3xx
+// short-circuits.
+func TestAPIClientRefusesRedirectChain(t *testing.T) {
+	var hop1Hits, hop2Hits int32
+
+	hop2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hop2Hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hop2.Close()
+
+	hop1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hop1Hits, 1)
+		w.Header().Set("Location", hop2.URL)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer hop1.Close()
+
+	gleif := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", hop1.URL)
+		w.WriteHeader(http.StatusMovedPermanently)
+	}))
+	defer gleif.Close()
+
+	c := newTestClient(gleif.URL)
+
+	_, _ = c.GetLEI(context.Background(), "529900T8BM49AURSDO55")
+
+	if h1 := atomic.LoadInt32(&hop1Hits); h1 != 0 {
+		t.Errorf("redirect-chain regression: hop1 was hit %d times; first 3xx should short-circuit", h1)
+	}
+	if h2 := atomic.LoadInt32(&hop2Hits); h2 != 0 {
+		t.Errorf("redirect-chain regression: hop2 was hit %d times; first 3xx should short-circuit", h2)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CheckRedirect` returning `http.ErrUseLastResponse` to the API client
- Closes the SSRF redirect-chain finding from the 2026-05-02 Carlini scaffold sweep
- Same shape as `mediawiki-mcp-server` API-client redirect refusal

## Why

GLEIF's API does not redirect under normal operation. Without `CheckRedirect`, Go follows up to 10 redirects with no host allowlist. A misconfigured `BaseURL` combined with a wiki/proxy returning `Location: http://169.254.169.254/...` would pivot a lookup into a fetch against cloud metadata or other link-local internal services, with the body landing in the agent context via the regular response path.

Returning `http.ErrUseLastResponse` short-circuits the redirect and surfaces the 3xx to the caller as an error.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -failfast ./...` passes
- [x] `golangci-lint run ./...` 0 issues
- [x] New `TestAPIClientRefusesRedirectToInternalIP` verifies the attacker-stand-in server is never hit
- [x] New `TestAPIClientRefusesRedirectChain` verifies the first 3xx short-circuits (no walk through hop1 → hop2)

## Outstanding (separate work)

Two MEDIUM findings remain on gleif from the same sweep:
- shared `*LEIRecord` pointer cached and returned (latent mutation hazard)
- no `singleflight` on cold cache (combines with rate limiter for amplification)

Tracked in `claude-code-config/memory/autonomous_vuln_scaffold.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)