### PR TITLE
fix(correctness): deep-copy LEI records on cache store and retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - API client refuses all redirects via `CheckRedirect` returning `http.ErrUseLastResponse`. The GLEIF API does not redirect under normal operation; without this guard, a misconfigured `BaseURL` or a wiki/proxy returning `Location: http://169.254.169.254/...` would pivot a lookup into a fetch against cloud metadata or other link-local internal services, with the body landing in the agent context. (security)
+- LEI record cache no longer returns aliased pointers. Previously `SetLEI` stored the caller's pointer as-is and `GetLEI` handed the same pointer to every cache-hit caller; any future handler mutating a returned field (redaction, normalization, locale fix-ups) would silently corrupt cached state for every other concurrent caller. Cache now deep-copies on both store and retrieval. (correctness)
 
 ## [0.8.0] - 2026-05-03
 

--- a/internal/gleif/cache.go
+++ b/internal/gleif/cache.go
@@ -1,11 +1,37 @@
 package gleif
 
 import (
+	"encoding/json"
 	"sync"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 )
+
+// cloneLEIRecord returns a deep copy of an LEIRecord. LEIRecord contains
+// nested slices (OtherNames, AddressLines) and pointer fields
+// (AssociatedEntity, SuccessorEntity, ValidationAuthority,
+// EntityExpirationDate/Reason), so a value copy of the top-level struct
+// would still share inner state. JSON round-trip is the simplest deep
+// copy that stays correct as the type evolves; cost is a few µs per
+// call, negligible against any GLEIF round-trip.
+//
+// Returns (nil, error) on marshal/unmarshal failure. Callers treat that
+// as a cache miss / silent skip rather than failing the request.
+func cloneLEIRecord(r *LEIRecord) (*LEIRecord, error) {
+	if r == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+	var out LEIRecord
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
 
 // CacheConfig configures the cache behavior.
 type CacheConfig struct {
@@ -92,7 +118,8 @@ func NewCache(config CacheConfig) (*Cache, error) {
 	}, nil
 }
 
-// GetLEI retrieves a cached LEI record.
+// GetLEI retrieves a cached LEI record. Returns a deep copy so callers can
+// freely mutate without affecting the cache or other concurrent callers.
 func (c *Cache) GetLEI(lei string) (*LEIRecord, bool) {
 	if !c.config.Enabled || c.leiCache == nil {
 		return nil, false
@@ -109,20 +136,37 @@ func (c *Cache) GetLEI(lei string) (*LEIRecord, bool) {
 		return nil, false
 	}
 
+	out, err := cloneLEIRecord(entry.value)
+	if err != nil || out == nil {
+		// Treat clone failure as a cache miss rather than risk handing
+		// the shared pointer back to the caller.
+		c.mu.Lock()
+		c.stats.Misses++
+		c.mu.Unlock()
+		return nil, false
+	}
+
 	c.mu.Lock()
 	c.stats.Hits++
 	c.mu.Unlock()
-	return entry.value, true
+	return out, true
 }
 
-// SetLEI caches an LEI record.
+// SetLEI caches an LEI record. Stores a deep copy so subsequent caller
+// mutations of the passed-in record don't leak into the cache.
 func (c *Cache) SetLEI(lei string, record *LEIRecord) {
 	if !c.config.Enabled || c.leiCache == nil {
 		return
 	}
 
+	stored, err := cloneLEIRecord(record)
+	if err != nil || stored == nil {
+		// Skip caching rather than store an aliased pointer.
+		return
+	}
+
 	c.leiCache.Add(lei, cacheEntry[*LEIRecord]{
-		value:     record,
+		value:     stored,
 		expiresAt: time.Now().Add(c.config.LEIRecordTTL),
 	})
 }

--- a/internal/gleif/cache_isolation_test.go
+++ b/internal/gleif/cache_isolation_test.go
@@ -1,0 +1,99 @@
+package gleif
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCacheReturnsIndependentCopies is the regression test for the
+// shared-pointer finding from the 2026-05-02 Carlini scaffold sweep.
+//
+// Before the fix: SetLEI stored the caller's pointer as-is and GetLEI
+// returned the stored pointer. Five concurrent callers asking for the
+// same LEI received the identical *LEIRecord. Any future handler that
+// mutated a returned field (redaction, normalization, locale fix-ups)
+// would silently corrupt the cache for every other caller.
+//
+// After the fix: SetLEI stores a deep copy and GetLEI returns a deep
+// copy. Caller mutations stay local.
+func TestCacheReturnsIndependentCopies(t *testing.T) {
+	cache, err := NewCache(CacheConfig{
+		LEIRecordTTL: time.Hour,
+		MaxEntries:   10,
+		Enabled:      true,
+	})
+	if err != nil {
+		t.Fatalf("NewCache: %v", err)
+	}
+
+	original := &LEIRecord{
+		LEI: "TESTABC1234567890123",
+		Entity: Entity{
+			LegalName: LegalName{Name: "Acme Corp", Language: "en"},
+			OtherNames: []OtherName{
+				{Name: "Acme", Type: "TRADING"},
+			},
+			LegalAddress: Address{
+				AddressLines: []string{"123 Main St", "Suite 4"},
+				City:         "Springfield",
+				Country:      "US",
+			},
+		},
+	}
+
+	cache.SetLEI(original.LEI, original)
+
+	// Mutate the original after Set; cache must not reflect this.
+	original.Entity.LegalName.Name = "MUTATED-AFTER-SET"
+	original.Entity.OtherNames[0].Name = "ALSO-MUTATED"
+	original.Entity.LegalAddress.AddressLines[0] = "EVIL"
+
+	a, ok := cache.GetLEI(original.LEI)
+	if !ok {
+		t.Fatal("expected cache hit, got miss")
+	}
+	if a.Entity.LegalName.Name != "Acme Corp" {
+		t.Errorf("Set-side aliasing: cached name = %q, want %q", a.Entity.LegalName.Name, "Acme Corp")
+	}
+	if a.Entity.OtherNames[0].Name != "Acme" {
+		t.Errorf("Set-side aliasing on slice: cached OtherNames[0] = %q, want %q", a.Entity.OtherNames[0].Name, "Acme")
+	}
+	if a.Entity.LegalAddress.AddressLines[0] != "123 Main St" {
+		t.Errorf("Set-side aliasing on AddressLines: got %q, want %q", a.Entity.LegalAddress.AddressLines[0], "123 Main St")
+	}
+
+	// Mutate caller A's copy; caller B (also Get) must see clean data.
+	a.Entity.LegalName.Name = "POISONED-BY-A"
+	a.Entity.OtherNames[0].Name = "POISONED-NESTED"
+	a.Entity.LegalAddress.AddressLines[0] = "POISONED-SLICE"
+
+	b, ok := cache.GetLEI(original.LEI)
+	if !ok {
+		t.Fatal("expected second cache hit, got miss")
+	}
+	if b.Entity.LegalName.Name != "Acme Corp" {
+		t.Errorf("Get-side aliasing: caller-B name = %q, want %q (caller A poisoned it via shared pointer)", b.Entity.LegalName.Name, "Acme Corp")
+	}
+	if b.Entity.OtherNames[0].Name != "Acme" {
+		t.Errorf("Get-side aliasing on slice: caller-B OtherNames[0] = %q, want %q", b.Entity.OtherNames[0].Name, "Acme")
+	}
+	if b.Entity.LegalAddress.AddressLines[0] != "123 Main St" {
+		t.Errorf("Get-side aliasing on AddressLines: caller-B got %q, want %q", b.Entity.LegalAddress.AddressLines[0], "123 Main St")
+	}
+
+	// And a and b must themselves be distinct allocations (different pointers).
+	if a == b {
+		t.Error("GetLEI returned the same pointer to two callers; they should each get an independent copy")
+	}
+}
+
+// TestCloneLEIRecord_Nil ensures the helper handles nil safely.
+func TestCloneLEIRecord_Nil(t *testing.T) {
+	out, err := cloneLEIRecord(nil)
+	if err != nil {
+		t.Errorf("cloneLEIRecord(nil) returned err = %v, want nil", err)
+	}
+	if out != nil {
+		t.Errorf("cloneLEIRecord(nil) returned %v, want nil", out)
+	}
+}


### PR DESCRIPTION
## Summary

- `cloneLEIRecord` helper does a deep copy via JSON round-trip
- `SetLEI` clones before storing; `GetLEI` clones before returning
- Closes the shared-pointer finding from the 2026-05-02 Carlini scaffold sweep

## Why

`SetLEI` stored the caller's pointer as-is and `GetLEI` returned the stored pointer. Five concurrent callers asking for the same LEI received the identical `*LEIRecord`. Any future handler mutating a returned field (redaction, normalization, locale fix-ups) would silently corrupt cached state for every other caller.

This is latent today — no current handler mutates returned records — but it's the kind of trap that bites during the next refactor. The fix removes the trap before someone steps on it.

## Why JSON round-trip

`LEIRecord` has nested slices (`OtherNames`, `AddressLines`) and pointer fields (`AssociatedEntity`, `SuccessorEntity`, `ValidationAuthority`, `EntityExpirationDate`/`Reason`). A value copy of the top-level struct still shares those. JSON round-trip stays correct as the type evolves; cost is a few µs per cache cycle, negligible against any GLEIF round-trip.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -failfast ./...` passes
- [x] `golangci-lint run ./...` 0 issues
- [x] `TestCacheReturnsIndependentCopies` verifies:
  - mutating original after `SetLEI` does not corrupt cached copy
  - mutating caller-A's `GetLEI` result does not corrupt caller-B's later `GetLEI`
  - both top-level fields and nested slice elements stay isolated
- [x] `TestCloneLEIRecord_Nil` verifies nil input is handled safely

## Outstanding

Last MEDIUM finding remaining on gleif from the 2026-05-02 sweep: no `singleflight` on cold cache (combines with rate limiter for amplification). Tracked in `claude-code-config/memory/autonomous_vuln_scaffold.md`.

Search cache (`[]LEIRecord`) has the same shape of risk and could benefit from the same treatment in a follow-up. Scope kept tight to the named finding here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)