### PR TITLE
fix(security): collapse concurrent GetLEI misses via singleflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - API client refuses all redirects via `CheckRedirect` returning `http.ErrUseLastResponse`. The GLEIF API does not redirect under normal operation; without this guard, a misconfigured `BaseURL` or a wiki/proxy returning `Location: http://169.254.169.254/...` would pivot a lookup into a fetch against cloud metadata or other link-local internal services, with the body landing in the agent context. (security)
 - LEI record cache no longer returns aliased pointers. Previously `SetLEI` stored the caller's pointer as-is and `GetLEI` handed the same pointer to every cache-hit caller; any future handler mutating a returned field (redaction, normalization, locale fix-ups) would silently corrupt cached state for every other concurrent caller. Cache now deep-copies on both store and retrieval. (correctness)
+- `GetLEI` cold-path fetches now collapse via `singleflight.Group`. Previously, N concurrent callers asking for the same uncached LEI each consumed a slot in the shared rate limiter (50 rpm, burst 10), trivially draining it; now one leader does the upstream round-trip and followers receive the leader's result. Closes the rate-limit-amplification surface that made the (now-fixed) 24-hour validation cache poison reachable from a single client. (security)
 
 ## [0.8.0] - 2026-05-03
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/modelcontextprotocol/go-sdk v1.5.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=

--- a/internal/gleif/client.go
+++ b/internal/gleif/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/singleflight"
 	"golang.org/x/time/rate"
 )
 
@@ -102,6 +103,15 @@ type Client struct {
 	limiter    *rate.Limiter
 	cache      *Cache
 	config     Config
+	// sfGroup collapses N concurrent calls for the same uncached key into
+	// a single upstream fetch. Without it, a burst of identical requests
+	// during a cold-cache window each consume a slot in the shared rate
+	// limiter (50 rpm, burst 10), trivially draining it. Combined with
+	// the validation cache logic, that drain is what made the (now-fixed)
+	// 24-hour cache-poisoning trigger reachable from a single client.
+	// Used today for GetLEI; other cacheable methods may adopt the same
+	// pattern in follow-up changes.
+	sfGroup singleflight.Group
 }
 
 // NewClient creates a new GLEIF client.
@@ -152,27 +162,44 @@ func (c *Client) GetLEI(ctx context.Context, lei string) (*LEIRecord, error) {
 		return nil, NewInvalidFormatError("LEI", "must be 20 alphanumeric characters")
 	}
 
-	// Check cache first
+	// Cache hit fast-path (no singleflight overhead on the warm path).
 	if record, ok := c.cache.GetLEI(lei); ok {
 		c.logger.Debug("Cache hit for LEI", "lei", lei)
 		return record, nil
 	}
 
-	reqURL := fmt.Sprintf("%s/lei-records/%s", c.baseURL, lei)
-	c.logger.Debug("Fetching LEI", "lei", lei, "url", reqURL)
+	// Cold path: collapse N concurrent callers for the same LEI into a
+	// single upstream fetch. The leader does the GLEIF round-trip and
+	// populates the cache; followers receive the leader's result without
+	// consuming a rate-limit slot of their own.
+	v, err, _ := c.sfGroup.Do("lei:"+lei, func() (any, error) {
+		// Re-check cache inside the singleflight: a previous leader for
+		// this same key may have populated it between our outer miss and
+		// our turn here. (Cache hit paths return a cloned record per the
+		// cache_isolation fix; that contract holds here too.)
+		if record, ok := c.cache.GetLEI(lei); ok {
+			return record, nil
+		}
 
-	var resp SingleResponse[LEIRecord]
-	if err := c.doRequestWithRetry(ctx, reqURL, &resp); err != nil {
+		reqURL := fmt.Sprintf("%s/lei-records/%s", c.baseURL, lei)
+		c.logger.Debug("Fetching LEI", "lei", lei, "url", reqURL)
+
+		var resp SingleResponse[LEIRecord]
+		if err := c.doRequestWithRetry(ctx, reqURL, &resp); err != nil {
+			return nil, err
+		}
+
+		record := resp.Data.Attributes
+		record.LEI = resp.Data.ID
+
+		c.cache.SetLEI(lei, &record)
+		return &record, nil
+	})
+
+	if err != nil {
 		return nil, err
 	}
-
-	record := resp.Data.Attributes
-	record.LEI = resp.Data.ID
-
-	// Cache the result
-	c.cache.SetLEI(lei, &record)
-
-	return &record, nil
+	return v.(*LEIRecord), nil
 }
 
 // GetBatchLEI retrieves multiple LEI records in one request.

--- a/internal/gleif/singleflight_test.go
+++ b/internal/gleif/singleflight_test.go
@@ -1,0 +1,134 @@
+package gleif
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestGetLEI_SingleflightCollapsesConcurrentMisses is the regression test
+// for the cold-cache rate-limit-amplification finding from the 2026-05-02
+// Carlini scaffold sweep.
+//
+// Before the fix: 50 concurrent callers asking for the same uncached LEI
+// each consumed a slot in the shared rate limiter (50 rpm, burst 10),
+// trivially draining it. Combined with the (now-fixed) validation cache
+// that treated every error as "not found" for 24 hours, this turned a
+// momentary burst into a day-long cache poison reachable from a single
+// client.
+//
+// After the fix: GetLEI wraps the cold-path fetch with a singleflight.Group.
+// One leader does the upstream round-trip; followers receive the leader's
+// result. Upstream sees 1 request, not N.
+func TestGetLEI_SingleflightCollapsesConcurrentMisses(t *testing.T) {
+	const lei = "529900T8BM49AURSDO55"
+	const concurrentCallers = 50
+
+	// Test server: counts requests, blocks until released so all callers
+	// pile up before the leader's response unblocks them.
+	var requestCount int32
+	release := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		<-release
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":{"type":"lei-records","id":"` + lei + `","attributes":{"lei":"` + lei +
+			`","entity":{"legalName":{"name":"Acme Corp","language":"en"},"legalAddress":{"city":"X","country":"US"},"headquartersAddress":{"city":"X","country":"US"},"jurisdiction":"US","status":"ACTIVE"},"registration":{"initialRegistrationDate":"2020-01-01T00:00:00Z","lastUpdateDate":"2024-01-01T00:00:00Z","status":"ISSUED","nextRenewalDate":"2025-01-01T00:00:00Z","managingLou":"TESTLOU"}}}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+
+	// Spawn N callers; they all block in the singleflight Do until the
+	// leader's response unblocks via release.
+	results := make([]*LEIRecord, concurrentCallers)
+	errs := make([]error, concurrentCallers)
+	var wg sync.WaitGroup
+	wg.Add(concurrentCallers)
+
+	for i := range concurrentCallers {
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = c.GetLEI(context.Background(), lei)
+		}(i)
+	}
+
+	// Give callers time to all enter the singleflight Do.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	hits := atomic.LoadInt32(&requestCount)
+	if hits != 1 {
+		t.Errorf("singleflight regression: %d concurrent callers caused %d upstream requests, want 1", concurrentCallers, hits)
+	}
+
+	// All callers must have received a successful, valid result.
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("caller %d: unexpected error: %v", i, err)
+		}
+	}
+	for i, r := range results {
+		if r == nil || r.LEI != lei {
+			t.Errorf("caller %d: got %+v, want LEI %q", i, r, lei)
+		}
+	}
+}
+
+// TestGetLEI_SingleflightDoesNotShareErrors verifies that an upstream error
+// is propagated to all in-flight callers (they all see the same error) but
+// a subsequent call after the failure can succeed if the upstream recovers.
+// Singleflight's behavior: the leader's error is returned to all followers
+// of the same in-flight call, but the singleflight key is released after
+// the leader returns, so the next call starts a fresh upstream request.
+func TestGetLEI_SingleflightDoesNotShareErrors(t *testing.T) {
+	const lei = "529900T8BM49AURSDO55"
+
+	var requestCount int32
+	failFirst := make(chan struct{})
+	close(failFirst) // first request fails
+
+	var firstFailed atomic.Bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		if firstFailed.CompareAndSwap(false, true) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"errors":[{"status":"500"}]}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":{"type":"lei-records","id":"` + lei + `","attributes":{"lei":"` + lei +
+			`","entity":{"legalName":{"name":"Acme","language":"en"},"legalAddress":{"city":"X","country":"US"},"headquartersAddress":{"city":"X","country":"US"},"jurisdiction":"US","status":"ACTIVE"},"registration":{"initialRegistrationDate":"2020-01-01T00:00:00Z","lastUpdateDate":"2024-01-01T00:00:00Z","status":"ISSUED","nextRenewalDate":"2025-01-01T00:00:00Z","managingLou":"TESTLOU"}}}}`))
+	}))
+	defer srv.Close()
+
+	// Use a client with no retries to keep the first failure observable.
+	c := newTestClient(srv.URL)
+	c.config.MaxRetries = 0
+
+	if _, err := c.GetLEI(context.Background(), lei); err == nil {
+		t.Fatal("first call: expected error from 500, got nil")
+	}
+
+	// Second call must NOT reuse the failed singleflight result; it must
+	// hit upstream again (which now succeeds).
+	r, err := c.GetLEI(context.Background(), lei)
+	if err != nil {
+		t.Fatalf("second call: unexpected error: %v", err)
+	}
+	if r == nil || r.LEI != lei {
+		t.Errorf("second call: got %+v, want LEI %q", r, lei)
+	}
+
+	// Two upstream requests total: 1 failed, 1 succeeded.
+	if hits := atomic.LoadInt32(&requestCount); hits != 2 {
+		t.Errorf("expected 2 upstream requests (1 fail + 1 success), got %d", hits)
+	}
+}


### PR DESCRIPTION
## Summary

- Wraps `GetLEI` cold-path fetch with `singleflight.Group`
- One leader does the upstream round-trip; N followers receive its result without consuming rate-limit slots
- Adds `golang.org/x/sync` dependency
- Closes the last MEDIUM finding from the 2026-05-02 Carlini scaffold sweep on gleif

## Why

50 concurrent callers asking for the same uncached LEI previously each consumed a slot in the shared rate limiter (50 rpm, burst 10). A single client opening 50 connections to the same uncached LEI could drain the limiter in one burst.

Combined with the (now-fixed) validation cache that treated every error as "not found" for 24 hours, this turned a brief amplification into a day-long cache poison reachable from a single source. With the cache fix in `168b2a0` already in place, the day-long-poison is closed; this PR closes the amplification surface itself.

## Why not also wrap ValidateLEI / search / autocomplete?

- **ValidateLEI** calls `GetLEI` internally and inherits dedup transitively — wrapping it again would dedup only the local result-construction (cheap), not the upstream cost (already deduped).
- **Search and autocomplete** have the same shape of risk but with more complex cache keys. Worth a follow-up; out of scope here to keep the PR reviewable.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race -failfast ./...` passes (race detector important for singleflight tests)
- [x] `golangci-lint run ./...` 0 issues
- [x] `TestGetLEI_SingleflightCollapsesConcurrentMisses`: 50 concurrent callers for the same uncached LEI cause exactly 1 upstream request, all callers receive a valid result
- [x] `TestGetLEI_SingleflightDoesNotShareErrors`: failed singleflight call doesn't poison the key — a subsequent caller after the failure can retry and succeed when the upstream recovers

## Outstanding

Search and autocomplete cache paths are the natural follow-up. After this lands, gleif has zero open Carlini scaffold findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)