### PR TITLE
refactor(codescene): bring Code Health to Green tier across all source files

### DIFF
--- a/internal/gleif/client.go
+++ b/internal/gleif/client.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"regexp"
-	"strings"
 	"time"
 
 	"golang.org/x/sync/singleflight"
@@ -22,52 +20,13 @@ const (
 	// DefaultTimeout for HTTP requests.
 	DefaultTimeout = 30 * time.Second
 
-	// LEI format: 20 alphanumeric characters.
-	LEIPattern = `^[A-Z0-9]{4}[A-Z0-9]{2}[A-Z0-9]{12}[0-9]{2}$`
-
-	// ISIN format: 2-letter country code + 9 alphanumeric + 1 check digit (12 total).
-	// Matches the Pattern declared in tools/definitions.go for search_by_isin.
-	ISINPattern = `^[A-Z]{2}[A-Z0-9]{10}$`
-
-	// BIC format: 8 or 11 characters (matches search_by_bic tool spec Pattern).
-	BICPattern = `^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$`
-
-	// CountryPattern: ISO 3166-1 alpha-2.
-	CountryPattern = `^[A-Z]{2}$`
-
-	// IssuerIDPattern: LEI issuer (LOU) ID. GLEIF issues these as 20-character
-	// alphanumeric (often the LEI of the issuing organization), but historic
-	// IDs can be shorter alphanumeric tokens. Allow 4-32 alphanumeric chars to
-	// cover both shapes without admitting URL-pivot characters.
-	IssuerIDPattern = `^[A-Z0-9]{4,32}$`
-
 	// Rate limit: GLEIF allows 60/min, we use 50 to be safe.
 	DefaultRateLimit = 50.0 / 60.0 // ~0.83 requests per second
 	DefaultBurstSize = 10
-)
 
-var (
-	leiRegex      = regexp.MustCompile(LEIPattern)
-	isinRegex     = regexp.MustCompile(ISINPattern)
-	bicRegex      = regexp.MustCompile(BICPattern)
-	countryRegex  = regexp.MustCompile(CountryPattern)
-	issuerIDRegex = regexp.MustCompile(IssuerIDPattern)
+	// maxBatchSize is the upper bound on a single batch lookup.
+	maxBatchSize = 100
 )
-
-// ValidateIssuerID checks that an LEI issuer (LOU) ID is well-formed and
-// safe for URL-path interpolation. Without this check, an adversarial MCP
-// caller could send issuer_id="../lei-records/SOMELEI" and pivot the
-// request away from /lei-issuers/ to a different GLEIF endpoint.
-func ValidateIssuerID(id string) error {
-	id = strings.ToUpper(strings.TrimSpace(id))
-	if id == "" {
-		return NewInvalidFormatError("issuer_id", "is required")
-	}
-	if !issuerIDRegex.MatchString(id) {
-		return NewInvalidFormatError("issuer_id", "must be 4-32 alphanumeric characters")
-	}
-	return nil
-}
 
 // Config holds client configuration.
 type Config struct {
@@ -137,10 +96,6 @@ func NewClient(config Config, logger *slog.Logger) *Client {
 			// 3xx responses; a misconfigured deployment combined with a wiki
 			// or proxy returning Location: http://169.254.169.254/... would
 			// pivot the request to internal IPs (cloud metadata, link-local).
-			// GLEIF's API does not redirect under normal operation, so any
-			// 3xx is either misconfiguration or an SSRF attempt. Returning
-			// http.ErrUseLastResponse short-circuits the redirect and
-			// surfaces the 3xx to the caller as an error.
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
@@ -158,7 +113,6 @@ func (c *Client) doRequestWithRetry(ctx context.Context, url string, result any)
 	var lastErr error
 
 	for attempt := 0; attempt <= c.config.MaxRetries; attempt++ {
-		// Wait for rate limiter
 		if err := c.limiter.Wait(ctx); err != nil {
 			return NewRateLimitError(60)
 		}
@@ -169,20 +123,13 @@ func (c *Client) doRequestWithRetry(ctx context.Context, url string, result any)
 		}
 
 		lastErr = err
-
-		// Check if retryable
 		if !IsRetryable(err) {
 			return err
 		}
 
-		// Exponential backoff
 		if attempt < c.config.MaxRetries {
-			delay := c.config.RetryDelay * time.Duration(1<<attempt)
-			c.logger.Debug("Retrying request", "attempt", attempt+1, "delay", delay, "error", err)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(delay):
+			if waitErr := c.waitForRetry(ctx, attempt, err); waitErr != nil {
+				return waitErr
 			}
 		}
 	}
@@ -190,13 +137,42 @@ func (c *Client) doRequestWithRetry(ctx context.Context, url string, result any)
 	return lastErr
 }
 
+// waitForRetry sleeps with exponential backoff and respects context cancellation.
+func (c *Client) waitForRetry(ctx context.Context, attempt int, err error) error {
+	delay := c.config.RetryDelay * time.Duration(1<<attempt)
+	c.logger.Debug("Retrying request", "attempt", attempt+1, "delay", delay, "error", err)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(delay):
+		return nil
+	}
+}
+
 // doRequest executes an HTTP GET request and decodes the JSON response.
 func (c *Client) doRequest(ctx context.Context, url string, result any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	body, statusCode, err := c.executeAndRead(ctx, url)
 	if err != nil {
-		return NewNetworkError(err)
+		return err
 	}
 
+	if statusErr := mapStatusToError(statusCode); statusErr != nil {
+		return statusErr
+	}
+
+	if err := json.Unmarshal(body, result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	return nil
+}
+
+// executeAndRead builds the request, executes it, and reads the response body.
+// Extracted from doRequest to flatten its conditional structure.
+func (c *Client) executeAndRead(ctx context.Context, reqURL string) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, 0, NewNetworkError(err)
+	}
 	req.Header.Set("Accept", "application/vnd.api+json")
 	req.Header.Set("Accept-Encoding", "gzip")
 	req.Header.Set("User-Agent", "gleif-mcp-server/0.2.0")
@@ -204,47 +180,41 @@ func (c *Client) doRequest(ctx context.Context, url string, result any) error {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if ctx.Err() != nil {
-			return NewTimeoutError()
+			return nil, 0, NewTimeoutError()
 		}
-		return NewNetworkError(err)
+		return nil, 0, NewNetworkError(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return NewNetworkError(err)
+		return nil, resp.StatusCode, NewNetworkError(err)
 	}
+	return body, resp.StatusCode, nil
+}
 
-	switch resp.StatusCode {
-	case http.StatusOK:
-		// Success
-	case http.StatusNotFound:
+// mapStatusToError maps an HTTP status code to a sanitized APIError. Returns
+// nil for 200 OK. Never includes raw response bodies in the returned error;
+// HG-2 in code-review-prompts.md requires sanitization at this boundary so
+// HTML/CDN error pages and prompt-injection echoes never reach the MCP caller.
+func mapStatusToError(statusCode int) error {
+	switch {
+	case statusCode == http.StatusOK:
+		return nil
+	case statusCode == http.StatusNotFound:
 		return NewNotFoundError("LEI record")
-	case http.StatusTooManyRequests:
+	case statusCode == http.StatusTooManyRequests:
 		return NewRateLimitError(60)
+	case statusCode >= 500:
+		return NewServerError(statusCode, "")
 	default:
-		// Don't leak raw response bodies into the MCP caller's error string.
-		// HTML/CDN error pages, MITM proxy responses, and prompt-injection
-		// payloads in echoed input are all blocked at this gate. Operators
-		// can still recover the body via debug-level request logging; only
-		// the MCP caller's error string is sanitized. See HG-2 in
-		// rules/code-review-prompts.md.
-		if resp.StatusCode >= 500 {
-			return NewServerError(resp.StatusCode, "")
-		}
 		return &APIError{
 			Code:       ErrCodeServerError,
-			Message:    http.StatusText(resp.StatusCode),
-			StatusCode: resp.StatusCode,
+			Message:    http.StatusText(statusCode),
+			StatusCode: statusCode,
 			Retryable:  false,
 		}
 	}
-
-	if err := json.Unmarshal(body, result); err != nil {
-		return fmt.Errorf("decoding response: %w", err)
-	}
-
-	return nil
 }
 
 // CacheStats returns cache performance statistics.
@@ -255,4 +225,16 @@ func (c *Client) CacheStats() CacheStats {
 // ClearCache clears all cached data.
 func (c *Client) ClearCache() {
 	c.cache.Clear()
+}
+
+// extractLEIRecords lifts records out of a GLEIF JSON:API envelope, copying
+// the LEI from the JSON:API id field into the LEIRecord struct so callers
+// see a fully-populated record. Shared between lookup and search paths.
+func extractLEIRecords(resp APIResponse[LEIRecord]) []LEIRecord {
+	records := make([]LEIRecord, len(resp.Data))
+	for i, item := range resp.Data {
+		records[i] = item.Attributes
+		records[i].LEI = item.ID
+	}
+	return records
 }

--- a/internal/gleif/client_lookup.go
+++ b/internal/gleif/client_lookup.go
@@ -8,15 +8,12 @@ import (
 )
 
 // GetLEI retrieves a single LEI record by LEI code.
-func (c *Client) GetLEI(ctx context.Context, lei string) (*LEIRecord, error) {
-	lei = strings.ToUpper(strings.TrimSpace(lei))
-	if !leiRegex.MatchString(lei) {
-		return nil, NewInvalidFormatError("LEI", "must be 20 alphanumeric characters")
-	}
+func (c *Client) GetLEI(ctx context.Context, lei LEI) (*LEIRecord, error) {
+	key := string(lei)
 
 	// Cache hit fast-path (no singleflight overhead on the warm path).
-	if record, ok := c.cache.GetLEI(lei); ok {
-		c.logger.Debug("Cache hit for LEI", "lei", lei)
+	if record, ok := c.cache.GetLEI(key); ok {
+		c.logger.Debug("Cache hit for LEI", "lei", key)
 		return record, nil
 	}
 
@@ -24,28 +21,14 @@ func (c *Client) GetLEI(ctx context.Context, lei string) (*LEIRecord, error) {
 	// single upstream fetch. The leader does the GLEIF round-trip and
 	// populates the cache; followers receive the leader's result without
 	// consuming a rate-limit slot of their own.
-	v, err, _ := c.sfGroup.Do("lei:"+lei, func() (any, error) {
+	v, err, _ := c.sfGroup.Do("lei:"+key, func() (any, error) {
 		// Re-check cache inside the singleflight: a previous leader for
 		// this same key may have populated it between our outer miss and
-		// our turn here. (Cache hit paths return a cloned record per the
-		// cache_isolation fix; that contract holds here too.)
-		if record, ok := c.cache.GetLEI(lei); ok {
+		// our turn here.
+		if record, ok := c.cache.GetLEI(key); ok {
 			return record, nil
 		}
-
-		reqURL := fmt.Sprintf("%s/lei-records/%s", c.baseURL, lei)
-		c.logger.Debug("Fetching LEI", "lei", lei, "url", reqURL)
-
-		var resp SingleResponse[LEIRecord]
-		if err := c.doRequestWithRetry(ctx, reqURL, &resp); err != nil {
-			return nil, err
-		}
-
-		record := resp.Data.Attributes
-		record.LEI = resp.Data.ID
-
-		c.cache.SetLEI(lei, &record)
-		return &record, nil
+		return c.fetchLEIRecord(ctx, key)
 	})
 
 	if err != nil {
@@ -54,45 +37,66 @@ func (c *Client) GetLEI(ctx context.Context, lei string) (*LEIRecord, error) {
 	return v.(*LEIRecord), nil
 }
 
+// fetchLEIRecord performs the upstream GET for a single LEI and populates
+// the cache. Extracted from GetLEI's singleflight closure to keep that
+// closure short.
+func (c *Client) fetchLEIRecord(ctx context.Context, lei string) (*LEIRecord, error) {
+	reqURL := fmt.Sprintf("%s/lei-records/%s", c.baseURL, lei)
+	c.logger.Debug("Fetching LEI", "lei", lei, "url", reqURL)
+
+	var resp SingleResponse[LEIRecord]
+	if err := c.doRequestWithRetry(ctx, reqURL, &resp); err != nil {
+		return nil, err
+	}
+
+	record := resp.Data.Attributes
+	record.LEI = resp.Data.ID
+
+	c.cache.SetLEI(lei, &record)
+	return &record, nil
+}
+
 // GetBatchLEI retrieves multiple LEI records in one request.
-func (c *Client) GetBatchLEI(ctx context.Context, leis []string) ([]LEIRecord, error) {
+func (c *Client) GetBatchLEI(ctx context.Context, leis []LEI) ([]LEIRecord, error) {
 	if len(leis) == 0 {
 		return nil, NewInvalidFormatError("leis", "at least one LEI required")
 	}
-	if len(leis) > 100 {
-		return nil, NewInvalidFormatError("leis", "maximum 100 LEIs per request")
+	if len(leis) > maxBatchSize {
+		return nil, NewInvalidFormatError("leis", fmt.Sprintf("maximum %d LEIs per request", maxBatchSize))
 	}
 
-	// Validate and normalize all LEIs
-	normalized := make([]string, len(leis))
-	var cached []LEIRecord
-	var toFetch []string
-
-	for i, lei := range leis {
-		lei = strings.ToUpper(strings.TrimSpace(lei))
-		if !leiRegex.MatchString(lei) {
-			return nil, NewInvalidFormatError("LEI", fmt.Sprintf("invalid LEI at position %d: %s", i, lei))
-		}
-		normalized[i] = lei
-
-		// Check cache
-		if record, ok := c.cache.GetLEI(lei); ok {
-			cached = append(cached, *record)
-		} else {
-			toFetch = append(toFetch, lei)
-		}
-	}
-
-	// If all cached, return
+	cached, toFetch := c.partitionCachedLEIs(leis)
 	if len(toFetch) == 0 {
 		c.logger.Debug("All LEIs found in cache", "count", len(cached))
 		return cached, nil
 	}
 
-	// Fetch remaining
+	fetched, err := c.fetchBatchLEIs(ctx, toFetch)
+	if err != nil {
+		return nil, err
+	}
+	return append(cached, fetched...), nil
+}
+
+// partitionCachedLEIs splits a batch into cached records (returned directly)
+// and uncached LEIs that still need an upstream fetch.
+func (c *Client) partitionCachedLEIs(leis []LEI) (cached []LEIRecord, toFetch []string) {
+	for _, lei := range leis {
+		key := string(lei)
+		if record, ok := c.cache.GetLEI(key); ok {
+			cached = append(cached, *record)
+		} else {
+			toFetch = append(toFetch, key)
+		}
+	}
+	return cached, toFetch
+}
+
+// fetchBatchLEIs performs the upstream batch GET and populates the cache.
+func (c *Client) fetchBatchLEIs(ctx context.Context, toFetch []string) ([]LEIRecord, error) {
 	params := url.Values{}
 	params.Set("filter[lei]", strings.Join(toFetch, ","))
-	params.Set("page[size]", "100")
+	params.Set("page[size]", fmt.Sprintf("%d", maxBatchSize))
 
 	reqURL := fmt.Sprintf("%s/lei-records?%s", c.baseURL, params.Encode())
 	c.logger.Debug("Batch fetching LEIs", "count", len(toFetch), "url", reqURL)
@@ -108,7 +112,5 @@ func (c *Client) GetBatchLEI(ctx context.Context, leis []string) ([]LEIRecord, e
 		results[i].LEI = item.ID
 		c.cache.SetLEI(item.ID, &results[i])
 	}
-
-	// Combine cached and fetched
-	return append(cached, results...), nil
+	return results, nil
 }

--- a/internal/gleif/client_relationships.go
+++ b/internal/gleif/client_relationships.go
@@ -8,81 +8,86 @@ import (
 )
 
 // GetRelationships retrieves parent/child relationships for an LEI.
-func (c *Client) GetRelationships(ctx context.Context, lei string, relType string) ([]Relationship, error) {
-	lei = strings.ToUpper(strings.TrimSpace(lei))
-	if !leiRegex.MatchString(lei) {
-		return nil, NewInvalidFormatError("LEI", "must be 20 alphanumeric characters")
-	}
+func (c *Client) GetRelationships(ctx context.Context, lei LEI, relType string) ([]Relationship, error) {
+	endpoint := relationshipEndpoint(relType)
+	reqURL := fmt.Sprintf("%s/lei-records/%s/%s", c.baseURL, string(lei), endpoint)
+	c.logger.Debug("Fetching relationships", "lei", string(lei), "type", relType, "url", reqURL)
 
-	// Build relationship URL
-	var endpoint string
+	return c.fetchRelationships(ctx, reqURL)
+}
+
+// relationshipEndpoint maps a relationship type to its GLEIF endpoint
+// suffix. Unknown types fall through to direct-parent (matches the prior
+// switch's default arm).
+func relationshipEndpoint(relType string) string {
 	switch strings.ToLower(relType) {
-	case "direct-parent", "parent":
-		endpoint = "direct-parent-relationship"
 	case "ultimate-parent", "ultimate":
-		endpoint = "ultimate-parent-relationship"
+		return "ultimate-parent-relationship"
 	case "direct-children", "children":
-		endpoint = "direct-child-relationships"
+		return "direct-child-relationships"
 	case "fund-manager":
-		endpoint = "fund-manager-relationship"
+		return "fund-manager-relationship"
 	case "umbrella-fund":
-		endpoint = "umbrella-fund-relationship"
+		return "umbrella-fund-relationship"
 	case "sub-funds":
-		endpoint = "sub-fund-relationships"
+		return "sub-fund-relationships"
 	default:
-		// Get all relationships
-		endpoint = "direct-parent-relationship"
+		return "direct-parent-relationship"
+	}
+}
+
+// relData mirrors GLEIF's relationship envelope. Hoisted out of GetRelationships
+// so both array and single-shape decode paths share the same struct.
+type relData struct {
+	Type       string `json:"type"`
+	ID         string `json:"id"`
+	Attributes struct {
+		Relationship Relationship `json:"relationship"`
+	} `json:"attributes"`
+}
+
+// fetchRelationships handles GLEIF's two response shapes for relationship
+// endpoints: list (children/funds) and singleton (parent). Tries list first,
+// falls through to singleton on decode failure.
+func (c *Client) fetchRelationships(ctx context.Context, reqURL string) ([]Relationship, error) {
+	type relListResponse struct {
+		Data []relData `json:"data"`
+	}
+	type relSingleResponse struct {
+		Data relData `json:"data"`
 	}
 
-	reqURL := fmt.Sprintf("%s/lei-records/%s/%s", c.baseURL, lei, endpoint)
-	c.logger.Debug("Fetching relationships", "lei", lei, "type", relType, "url", reqURL)
-
-	// Relationship responses have a different structure
-	type RelData struct {
-		Type       string `json:"type"`
-		ID         string `json:"id"`
-		Attributes struct {
-			Relationship Relationship `json:"relationship"`
-		} `json:"attributes"`
-	}
-	type RelResponse struct {
-		Data []RelData `json:"data"`
+	var listResp relListResponse
+	listErr := c.doRequestWithRetry(ctx, reqURL, &listResp)
+	if listErr == nil {
+		return relationshipsFromList(listResp.Data), nil
 	}
 
-	var resp RelResponse
-	if err := c.doRequestWithRetry(ctx, reqURL, &resp); err != nil {
-		// Check if it's a single response (for parent relationships)
-		type SingleRelResponse struct {
-			Data RelData `json:"data"`
-		}
-		var singleResp SingleRelResponse
-		if err2 := c.doRequestWithRetry(ctx, reqURL, &singleResp); err2 != nil {
-			return nil, err
-		}
-		if singleResp.Data.ID != "" {
-			return []Relationship{singleResp.Data.Attributes.Relationship}, nil
-		}
-		return nil, err
+	var singleResp relSingleResponse
+	if err := c.doRequestWithRetry(ctx, reqURL, &singleResp); err != nil {
+		return nil, listErr
 	}
+	if singleResp.Data.ID == "" {
+		return nil, listErr
+	}
+	return []Relationship{singleResp.Data.Attributes.Relationship}, nil
+}
 
-	rels := make([]Relationship, len(resp.Data))
-	for i, item := range resp.Data {
+func relationshipsFromList(data []relData) []Relationship {
+	rels := make([]Relationship, len(data))
+	for i, item := range data {
 		rels[i] = item.Attributes.Relationship
 	}
-	return rels, nil
+	return rels
 }
 
 // GetLEIIssuer retrieves information about an LEI issuer (LOU).
-func (c *Client) GetLEIIssuer(ctx context.Context, issuerID string) (*LEIIssuer, error) {
-	if err := ValidateIssuerID(issuerID); err != nil {
-		return nil, err
-	}
-	issuerID = strings.ToUpper(strings.TrimSpace(issuerID))
+func (c *Client) GetLEIIssuer(ctx context.Context, issuerID IssuerID) (*LEIIssuer, error) {
 	// url.PathEscape is a no-op for validator-approved IDs (the regex already
 	// restricts to URL-safe chars), but stays as belt-and-braces against
 	// future regex loosening.
-	reqURL := fmt.Sprintf("%s/lei-issuers/%s", c.baseURL, url.PathEscape(issuerID))
-	c.logger.Debug("Fetching LEI issuer", "id", issuerID, "url", reqURL)
+	reqURL := fmt.Sprintf("%s/lei-issuers/%s", c.baseURL, url.PathEscape(string(issuerID)))
+	c.logger.Debug("Fetching LEI issuer", "id", string(issuerID), "url", reqURL)
 
 	var resp SingleResponse[LEIIssuer]
 	if err := c.doRequestWithRetry(ctx, reqURL, &resp); err != nil {
@@ -113,14 +118,9 @@ func (c *Client) ListLEIIssuers(ctx context.Context) ([]LEIIssuer, error) {
 }
 
 // GetReportingExceptions retrieves reporting exceptions for an LEI.
-func (c *Client) GetReportingExceptions(ctx context.Context, lei string) ([]ReportingException, error) {
-	lei = strings.ToUpper(strings.TrimSpace(lei))
-	if !leiRegex.MatchString(lei) {
-		return nil, NewInvalidFormatError("LEI", "must be 20 alphanumeric characters")
-	}
-
-	reqURL := fmt.Sprintf("%s/lei-records/%s/reporting-exceptions", c.baseURL, lei)
-	c.logger.Debug("Fetching reporting exceptions", "lei", lei, "url", reqURL)
+func (c *Client) GetReportingExceptions(ctx context.Context, lei LEI) ([]ReportingException, error) {
+	reqURL := fmt.Sprintf("%s/lei-records/%s/reporting-exceptions", c.baseURL, string(lei))
+	c.logger.Debug("Fetching reporting exceptions", "lei", string(lei), "url", reqURL)
 
 	var resp APIResponse[ReportingException]
 	if err := c.doRequestWithRetry(ctx, reqURL, &resp); err != nil {

--- a/internal/gleif/client_search.go
+++ b/internal/gleif/client_search.go
@@ -4,17 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 )
 
 // SearchEntities searches for entities by name with pagination.
 func (c *Client) SearchEntities(ctx context.Context, query string, limit, page int) ([]LEIRecord, *Pagination, error) {
-	if limit <= 0 || limit > 100 {
-		limit = 20
-	}
-	if page <= 0 {
-		page = 1
-	}
+	limit, page = clampLimitAndPage(limit, page)
 
 	params := url.Values{}
 	params.Set("filter[entity.legalName]", query)
@@ -29,24 +23,13 @@ func (c *Client) SearchEntities(ctx context.Context, query string, limit, page i
 		return nil, nil, err
 	}
 
-	records := make([]LEIRecord, len(resp.Data))
-	for i, item := range resp.Data {
-		records[i] = item.Attributes
-		records[i].LEI = item.ID
-	}
-	return records, &resp.Meta.Pagination, nil
+	return extractLEIRecords(resp), &resp.Meta.Pagination, nil
 }
 
 // FuzzySearch performs fuzzy matching on entity names with pagination.
 func (c *Client) FuzzySearch(ctx context.Context, query string, limit, page int) ([]LEIRecord, *Pagination, error) {
-	if limit <= 0 || limit > 100 {
-		limit = 20
-	}
-	if page <= 0 {
-		page = 1
-	}
+	limit, page = clampLimitAndPage(limit, page)
 
-	// Check cache (only for first page)
 	cacheKey := fmt.Sprintf("fuzzy:%s:%d:%d", query, limit, page)
 	if page == 1 {
 		if records, ok := c.cache.GetSearch(cacheKey); ok {
@@ -68,13 +51,7 @@ func (c *Client) FuzzySearch(ctx context.Context, query string, limit, page int)
 		return nil, nil, err
 	}
 
-	records := make([]LEIRecord, len(resp.Data))
-	for i, item := range resp.Data {
-		records[i] = item.Attributes
-		records[i].LEI = item.ID
-	}
-
-	// Cache first page results
+	records := extractLEIRecords(resp)
 	if page == 1 {
 		c.cache.SetSearch(cacheKey, records)
 	}
@@ -82,117 +59,97 @@ func (c *Client) FuzzySearch(ctx context.Context, query string, limit, page int)
 }
 
 // SearchByBIC finds LEI records by BIC/SWIFT code.
-func (c *Client) SearchByBIC(ctx context.Context, bic string) ([]LEIRecord, error) {
-	bic = strings.ToUpper(strings.TrimSpace(bic))
-	if !bicRegex.MatchString(bic) {
-		return nil, NewInvalidFormatError("BIC", "must be 8 or 11 characters: 4 letters + 2 letters + 2 alphanumeric, optional 3 alphanumeric")
-	}
-
-	// Check cache
-	cacheKey := fmt.Sprintf("bic:%s", bic)
+func (c *Client) SearchByBIC(ctx context.Context, bic BIC) ([]LEIRecord, error) {
+	cacheKey := "bic:" + string(bic)
 	if records, ok := c.cache.GetSearch(cacheKey); ok {
 		return records, nil
 	}
 
 	params := url.Values{}
-	params.Set("filter[bic]", bic)
+	params.Set("filter[bic]", string(bic))
 
 	reqURL := fmt.Sprintf("%s/lei-records?%s", c.baseURL, params.Encode())
-	c.logger.Debug("Searching by BIC", "bic", bic, "url", reqURL)
+	c.logger.Debug("Searching by BIC", "bic", string(bic), "url", reqURL)
 
 	var resp APIResponse[LEIRecord]
 	if err := c.doRequestWithRetry(ctx, reqURL, &resp); err != nil {
 		return nil, err
 	}
 
-	records := make([]LEIRecord, len(resp.Data))
-	for i, item := range resp.Data {
-		records[i] = item.Attributes
-		records[i].LEI = item.ID
-	}
-
+	records := extractLEIRecords(resp)
 	c.cache.SetSearch(cacheKey, records)
 	return records, nil
 }
 
-// SearchByISIN finds LEI records associated with an ISIN.
-func (c *Client) SearchByISIN(ctx context.Context, isin string) ([]LEIRecord, error) {
-	isin = strings.ToUpper(strings.TrimSpace(isin))
-	if !isinRegex.MatchString(isin) {
-		return nil, NewInvalidFormatError("ISIN", "must be 2 letters followed by 10 alphanumeric characters (12 total)")
-	}
-
-	// Check cache
-	cacheKey := fmt.Sprintf("isin:%s", isin)
+// SearchByISIN finds LEI records associated with an ISIN. GLEIF exposes two
+// endpoints (lei-issuer and lei-records) that can answer ISIN lookups; the
+// primary returns the issuer mapping, the fallback uses the generic record
+// filter when the primary path is unavailable.
+func (c *Client) SearchByISIN(ctx context.Context, isin ISIN) ([]LEIRecord, error) {
+	cacheKey := "isin:" + string(isin)
 	if records, ok := c.cache.GetSearch(cacheKey); ok {
 		return records, nil
 	}
 
-	// GLEIF uses the ISIN-LEI mapping endpoint. Build the URL via url.Values
-	// rather than raw fmt.Sprintf — an unvalidated value containing `&` could
-	// otherwise smuggle an additional query parameter past the intended one.
-	primaryParams := url.Values{}
-	primaryParams.Set("filter[isin]", isin)
-	reqURL := fmt.Sprintf("%s/lei-issuer?%s", c.baseURL, primaryParams.Encode())
-	c.logger.Debug("Searching by ISIN", "isin", isin, "url", reqURL)
-
-	var resp APIResponse[LEIRecord]
-	if err := c.doRequestWithRetry(ctx, reqURL, &resp); err != nil {
-		// Try alternative approach - search in lei-records with ISIN filter
-		params := url.Values{}
-		params.Set("filter[isin]", isin)
-		reqURL = fmt.Sprintf("%s/lei-records?%s", c.baseURL, params.Encode())
-
-		if err2 := c.doRequestWithRetry(ctx, reqURL, &resp); err2 != nil {
-			return nil, fmt.Errorf("ISIN lookup failed: %v", err)
-		}
+	resp, err := c.fetchISIN(ctx, isin)
+	if err != nil {
+		return nil, err
 	}
 
-	records := make([]LEIRecord, len(resp.Data))
-	for i, item := range resp.Data {
-		records[i] = item.Attributes
-		records[i].LEI = item.ID
-	}
-
+	records := extractLEIRecords(resp)
 	c.cache.SetSearch(cacheKey, records)
 	return records, nil
+}
+
+// fetchISIN tries the primary ISIN endpoint and falls back to the generic
+// lei-records filter if the primary path errors.
+func (c *Client) fetchISIN(ctx context.Context, isin ISIN) (APIResponse[LEIRecord], error) {
+	// Build the URL via url.Values rather than raw fmt.Sprintf — an
+	// unvalidated value containing `&` could otherwise smuggle an additional
+	// query parameter past the intended one.
+	primaryParams := url.Values{}
+	primaryParams.Set("filter[isin]", string(isin))
+	primaryURL := fmt.Sprintf("%s/lei-issuer?%s", c.baseURL, primaryParams.Encode())
+	c.logger.Debug("Searching by ISIN", "isin", string(isin), "url", primaryURL)
+
+	var resp APIResponse[LEIRecord]
+	if err := c.doRequestWithRetry(ctx, primaryURL, &resp); err == nil {
+		return resp, nil
+	}
+
+	fallbackParams := url.Values{}
+	fallbackParams.Set("filter[isin]", string(isin))
+	fallbackURL := fmt.Sprintf("%s/lei-records?%s", c.baseURL, fallbackParams.Encode())
+	if err := c.doRequestWithRetry(ctx, fallbackURL, &resp); err != nil {
+		return resp, fmt.Errorf("ISIN lookup failed: %w", err)
+	}
+	return resp, nil
 }
 
 // SearchByCountry finds entities in a specific country.
-func (c *Client) SearchByCountry(ctx context.Context, country string, limit int) ([]LEIRecord, error) {
-	if limit <= 0 || limit > 100 {
+func (c *Client) SearchByCountry(ctx context.Context, country Country, limit int) ([]LEIRecord, error) {
+	if limit <= 0 || limit > maxBatchSize {
 		limit = 20
 	}
 
-	country = strings.ToUpper(strings.TrimSpace(country))
-	if !countryRegex.MatchString(country) {
-		return nil, NewInvalidFormatError("country", "must be a 2-letter ISO 3166-1 alpha-2 code")
-	}
-
-	// Check cache
-	cacheKey := fmt.Sprintf("country:%s:%d", country, limit)
+	cacheKey := fmt.Sprintf("country:%s:%d", string(country), limit)
 	if records, ok := c.cache.GetSearch(cacheKey); ok {
 		return records, nil
 	}
 
 	params := url.Values{}
-	params.Set("filter[entity.legalAddress.country]", country)
+	params.Set("filter[entity.legalAddress.country]", string(country))
 	params.Set("page[size]", fmt.Sprintf("%d", limit))
 
 	reqURL := fmt.Sprintf("%s/lei-records?%s", c.baseURL, params.Encode())
-	c.logger.Debug("Searching by country", "country", country, "url", reqURL)
+	c.logger.Debug("Searching by country", "country", string(country), "url", reqURL)
 
 	var resp APIResponse[LEIRecord]
 	if err := c.doRequestWithRetry(ctx, reqURL, &resp); err != nil {
 		return nil, err
 	}
 
-	records := make([]LEIRecord, len(resp.Data))
-	for i, item := range resp.Data {
-		records[i] = item.Attributes
-		records[i].LEI = item.ID
-	}
-
+	records := extractLEIRecords(resp)
 	c.cache.SetSearch(cacheKey, records)
 	return records, nil
 }
@@ -203,42 +160,59 @@ func (c *Client) Autocomplete(ctx context.Context, prefix string, limit int) ([]
 		limit = 10
 	}
 
-	// Check cache
 	if results, ok := c.cache.GetAutocomplete(prefix); ok {
-		if len(results) > limit {
-			return results[:limit], nil
-		}
-		return results, nil
+		return applyLimit(results, limit), nil
 	}
 
 	params := url.Values{}
 	params.Set("q", prefix)
-
 	reqURL := fmt.Sprintf("%s/autocompletions?%s", c.baseURL, params.Encode())
 	c.logger.Debug("Autocomplete", "prefix", prefix, "url", reqURL)
 
 	var resp AutocompleteResponse
 	if err := c.doRequestWithRetry(ctx, reqURL, &resp); err != nil {
-		// Fallback to fuzzy search if autocomplete endpoint doesn't work
-		records, _, searchErr := c.FuzzySearch(ctx, prefix, limit, 1)
-		if searchErr != nil {
-			return nil, searchErr
-		}
-		results := make([]AutocompleteResult, len(records))
-		for i, r := range records {
-			results[i] = AutocompleteResult{
-				LEI:       r.LEI,
-				LegalName: r.Entity.LegalName.Name,
-				Country:   r.Entity.LegalAddress.Country,
-			}
-		}
-		return results, nil
+		return c.fuzzyAutocompleteFallback(ctx, prefix, limit)
 	}
 
 	c.cache.SetAutocomplete(prefix, resp.Data)
+	return applyLimit(resp.Data, limit), nil
+}
 
-	if len(resp.Data) > limit {
-		return resp.Data[:limit], nil
+// fuzzyAutocompleteFallback runs a fuzzy search and reshapes the records into
+// autocomplete suggestions when the primary autocomplete endpoint errors.
+func (c *Client) fuzzyAutocompleteFallback(ctx context.Context, prefix string, limit int) ([]AutocompleteResult, error) {
+	records, _, err := c.FuzzySearch(ctx, prefix, limit, 1)
+	if err != nil {
+		return nil, err
 	}
-	return resp.Data, nil
+	results := make([]AutocompleteResult, len(records))
+	for i, r := range records {
+		results[i] = AutocompleteResult{
+			LEI:       r.LEI,
+			LegalName: r.Entity.LegalName.Name,
+			Country:   r.Entity.LegalAddress.Country,
+		}
+	}
+	return results, nil
+}
+
+// clampLimitAndPage normalizes pagination inputs. Limits above 100 or below 1
+// fall back to the default 20; non-positive page numbers fall back to 1.
+func clampLimitAndPage(limit, page int) (int, int) {
+	if limit <= 0 || limit > maxBatchSize {
+		limit = 20
+	}
+	if page <= 0 {
+		page = 1
+	}
+	return limit, page
+}
+
+// applyLimit returns the first n elements of s, or all of s if it is shorter.
+// Centralizes the slice-or-return pattern that appeared in two cache-hit paths.
+func applyLimit[T any](s []T, n int) []T {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
 }

--- a/internal/gleif/client_test.go
+++ b/internal/gleif/client_test.go
@@ -43,9 +43,9 @@ func TestValidateLEICheckDigits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := validateLEICheckDigits(tt.lei)
+			got := LEI(tt.lei).HasValidCheckDigits()
 			if got != tt.valid {
-				t.Errorf("validateLEICheckDigits(%q) = %v, want %v", tt.lei, got, tt.valid)
+				t.Errorf("LEI(%q).HasValidCheckDigits() = %v, want %v", tt.lei, got, tt.valid)
 			}
 		})
 	}
@@ -124,18 +124,22 @@ func TestBICValidation(t *testing.T) {
 				EnableCache: false,
 			}, logger)
 
-			_, err := clientWithMock.SearchByBIC(context.Background(), tt.bic)
-
-			if tt.valid {
-				if err != nil {
-					var apiErr *APIError
-					if ok := isAPIError(err, &apiErr); ok && apiErr.Code == ErrCodeInvalidFormat {
-						t.Errorf("SearchByBIC(%q) returned format error, expected valid", tt.bic)
-					}
+			parsed, parseErr := ParseBIC(tt.bic)
+			if !tt.valid {
+				if parseErr == nil {
+					t.Errorf("ParseBIC(%q) = nil, expected error", tt.bic)
 				}
-			} else {
-				if err == nil {
-					t.Errorf("SearchByBIC(%q) = nil, expected error", tt.bic)
+				return
+			}
+			if parseErr != nil {
+				t.Errorf("ParseBIC(%q) returned error: %v", tt.bic, parseErr)
+				return
+			}
+			_, err := clientWithMock.SearchByBIC(context.Background(), parsed)
+			if err != nil {
+				var apiErr *APIError
+				if ok := isAPIError(err, &apiErr); ok && apiErr.Code == ErrCodeInvalidFormat {
+					t.Errorf("SearchByBIC(%q) returned format error, expected valid", tt.bic)
 				}
 			}
 		})
@@ -179,18 +183,22 @@ func TestISINValidation(t *testing.T) {
 				EnableCache: false,
 			}, logger)
 
-			_, err := clientWithMock.SearchByISIN(context.Background(), tt.isin)
-
-			if tt.valid {
-				if err != nil {
-					var apiErr *APIError
-					if ok := isAPIError(err, &apiErr); ok && apiErr.Code == ErrCodeInvalidFormat {
-						t.Errorf("SearchByISIN(%q) returned format error, expected valid", tt.isin)
-					}
+			parsed, parseErr := ParseISIN(tt.isin)
+			if !tt.valid {
+				if parseErr == nil {
+					t.Errorf("ParseISIN(%q) = nil, expected error", tt.isin)
 				}
-			} else {
-				if err == nil {
-					t.Errorf("SearchByISIN(%q) = nil, expected error", tt.isin)
+				return
+			}
+			if parseErr != nil {
+				t.Errorf("ParseISIN(%q) returned error: %v", tt.isin, parseErr)
+				return
+			}
+			_, err := clientWithMock.SearchByISIN(context.Background(), parsed)
+			if err != nil {
+				var apiErr *APIError
+				if ok := isAPIError(err, &apiErr); ok && apiErr.Code == ErrCodeInvalidFormat {
+					t.Errorf("SearchByISIN(%q) returned format error, expected valid", tt.isin)
 				}
 			}
 		})
@@ -233,18 +241,22 @@ func TestCountryValidation(t *testing.T) {
 				EnableCache: false,
 			}, logger)
 
-			_, err := clientWithMock.SearchByCountry(context.Background(), tt.country, 10)
-
-			if tt.valid {
-				if err != nil {
-					var apiErr *APIError
-					if ok := isAPIError(err, &apiErr); ok && apiErr.Code == ErrCodeInvalidFormat {
-						t.Errorf("SearchByCountry(%q) returned format error, expected valid", tt.country)
-					}
+			parsed, parseErr := ParseCountry(tt.country)
+			if !tt.valid {
+				if parseErr == nil {
+					t.Errorf("ParseCountry(%q) = nil, expected error", tt.country)
 				}
-			} else {
-				if err == nil {
-					t.Errorf("SearchByCountry(%q) = nil, expected error", tt.country)
+				return
+			}
+			if parseErr != nil {
+				t.Errorf("ParseCountry(%q) returned error: %v", tt.country, parseErr)
+				return
+			}
+			_, err := clientWithMock.SearchByCountry(context.Background(), parsed, 10)
+			if err != nil {
+				var apiErr *APIError
+				if ok := isAPIError(err, &apiErr); ok && apiErr.Code == ErrCodeInvalidFormat {
+					t.Errorf("SearchByCountry(%q) returned format error, expected valid", tt.country)
 				}
 			}
 		})
@@ -463,7 +475,7 @@ func TestGetLEIWithMockServer(t *testing.T) {
 			EnableCache: false,
 		}, logger)
 
-		record, err := client.GetLEI(context.Background(), "HWUPKR0MPOU8FGXBT394")
+		record, err := client.GetLEI(context.Background(), LEI("HWUPKR0MPOU8FGXBT394"))
 		if err != nil {
 			t.Fatalf("GetLEI failed: %v", err)
 		}
@@ -476,14 +488,11 @@ func TestGetLEIWithMockServer(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid LEI format", func(t *testing.T) {
-		client := NewClient(DefaultConfig(), logger)
-
-		_, err := client.GetLEI(context.Background(), "INVALID")
+	t.Run("invalid LEI format rejected at Parse", func(t *testing.T) {
+		_, err := ParseLEI("INVALID")
 		if err == nil {
-			t.Error("Expected error for invalid LEI")
+			t.Fatal("ParseLEI(\"INVALID\") returned nil; expected rejection")
 		}
-
 		var apiErr *APIError
 		if !isAPIError(err, &apiErr) || apiErr.Code != ErrCodeInvalidFormat {
 			t.Errorf("Expected invalid_format error, got %v", err)
@@ -505,7 +514,7 @@ func TestGetLEIWithMockServer(t *testing.T) {
 			EnableCache: false,
 		}, logger)
 
-		_, err := client.GetLEI(context.Background(), "HWUPKR0MPOU8FGXBT394")
+		_, err := client.GetLEI(context.Background(), LEI("HWUPKR0MPOU8FGXBT394"))
 		if err == nil {
 			t.Error("Expected error for not found")
 		}
@@ -531,7 +540,7 @@ func TestGetLEIWithMockServer(t *testing.T) {
 			EnableCache: false,
 		}, logger)
 
-		_, err := client.GetLEI(context.Background(), "HWUPKR0MPOU8FGXBT394")
+		_, err := client.GetLEI(context.Background(), LEI("HWUPKR0MPOU8FGXBT394"))
 		if err == nil {
 			t.Error("Expected error for rate limited")
 		}
@@ -549,16 +558,16 @@ func TestBatchLEIValidation(t *testing.T) {
 	client := NewClient(DefaultConfig(), logger)
 
 	t.Run("empty list", func(t *testing.T) {
-		_, err := client.GetBatchLEI(context.Background(), []string{})
+		_, err := client.GetBatchLEI(context.Background(), []LEI{})
 		if err == nil {
 			t.Error("Expected error for empty LEI list")
 		}
 	})
 
 	t.Run("too many LEIs", func(t *testing.T) {
-		leis := make([]string, 101)
+		leis := make([]LEI, 101)
 		for i := range leis {
-			leis[i] = "HWUPKR0MPOU8FGXBT394"
+			leis[i] = LEI("HWUPKR0MPOU8FGXBT394")
 		}
 		_, err := client.GetBatchLEI(context.Background(), leis)
 		if err == nil {
@@ -566,10 +575,12 @@ func TestBatchLEIValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid LEI in batch", func(t *testing.T) {
-		_, err := client.GetBatchLEI(context.Background(), []string{"HWUPKR0MPOU8FGXBT394", "INVALID"})
-		if err == nil {
-			t.Error("Expected error for invalid LEI in batch")
+	t.Run("invalid LEI rejected at Parse", func(t *testing.T) {
+		// With typed signatures, batch validation is the caller's concern.
+		// ParseLEI is the format gate; tools/handlers.parseBatchLEIs
+		// surfaces the first failure to the MCP caller.
+		if _, err := ParseLEI("INVALID"); err == nil {
+			t.Error("ParseLEI(\"INVALID\") returned nil; expected rejection")
 		}
 	})
 }

--- a/internal/gleif/client_validate.go
+++ b/internal/gleif/client_validate.go
@@ -4,53 +4,51 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 )
 
-// ValidateLEI checks if an LEI is valid and returns its status.
-func (c *Client) ValidateLEI(ctx context.Context, lei string) (*ValidationResult, error) {
-	lei = strings.ToUpper(strings.TrimSpace(lei))
+// ValidateLEI checks if an LEI is valid and returns its status. Unlike the
+// other lookups, this method takes a raw caller-supplied string because it
+// needs to report format and check-digit failures back to the caller as
+// validation results, not refuse to construct.
+func (c *Client) ValidateLEI(ctx context.Context, raw string) (*ValidationResult, error) {
+	normalized := normalize(raw)
 
-	// Check cache first
-	if result, ok := c.cache.GetValidation(lei); ok {
+	if result, ok := c.cache.GetValidation(normalized); ok {
 		return result, nil
 	}
 
-	result := &ValidationResult{LEI: lei}
+	result := &ValidationResult{LEI: normalized}
 
-	// First check format
-	if !leiRegex.MatchString(lei) {
+	parsed, err := ParseLEI(raw)
+	if err != nil {
 		result.Valid = false
 		result.Message = "Invalid LEI format: must be 20 alphanumeric characters"
 		return result, nil
 	}
 
-	// Validate check digits (ISO 17442)
-	if !validateLEICheckDigits(lei) {
+	if !parsed.HasValidCheckDigits() {
 		result.Valid = false
 		result.Message = "Invalid check digits: LEI fails ISO 17442 validation"
 		return result, nil
 	}
 
-	// Try to fetch the record. Only cache a negative result when GLEIF
-	// returned a definitive 404 — caching transient errors (5xx, timeout,
-	// rate-limit retry exhaustion) as "not found" would poison the cache
-	// for the configured ValidationTTL (24 hours by default), allowing an
-	// attacker who can briefly disrupt the upstream path (rate-limiter
-	// drain, network blip, GLEIF incident) to mark any LEI as invalid for
-	// the rest of the day.
+	return c.validateLEIAgainstAPI(ctx, parsed, result)
+}
+
+// validateLEIAgainstAPI fetches the record and shapes the validation result.
+// Only caches a definitive 404; transient errors propagate without cache write
+// to avoid the 24-hour cache-poisoning window that a network blip could open.
+func (c *Client) validateLEIAgainstAPI(ctx context.Context, lei LEI, result *ValidationResult) (*ValidationResult, error) {
 	record, err := c.GetLEI(ctx, lei)
 	if err != nil {
 		result.Valid = false
 		var apiErr *APIError
-		isDefinitiveNotFound := errors.As(err, &apiErr) && apiErr.Code == ErrCodeNotFound
-		if isDefinitiveNotFound {
+		if errors.As(err, &apiErr) && apiErr.Code == ErrCodeNotFound {
 			result.Message = "LEI not found in GLEIF database"
-			c.cache.SetValidation(lei, result)
-		} else {
-			// Transient — propagate the error context, do NOT cache.
-			result.Message = fmt.Sprintf("Validation unavailable: %s", err.Error())
+			c.cache.SetValidation(string(lei), result)
+			return result, nil
 		}
+		result.Message = fmt.Sprintf("Validation unavailable: %s", err.Error())
 		return result, nil
 	}
 
@@ -60,34 +58,6 @@ func (c *Client) ValidateLEI(ctx context.Context, lei string) (*ValidationResult
 	result.NextRenewal = record.Registration.NextRenewalDate.Format("2006-01-02")
 	result.Message = fmt.Sprintf("Valid LEI, registration status: %s", record.Registration.Status)
 
-	c.cache.SetValidation(lei, result)
+	c.cache.SetValidation(string(lei), result)
 	return result, nil
-}
-
-// validateLEICheckDigits validates the ISO 17442 check digits.
-func validateLEICheckDigits(lei string) bool {
-	if len(lei) != 20 {
-		return false
-	}
-
-	// Convert letters to numbers (A=10, B=11, ..., Z=35)
-	var numStr strings.Builder
-	for _, ch := range lei {
-		if ch >= 'A' && ch <= 'Z' {
-			fmt.Fprintf(&numStr, "%d", ch-'A'+10)
-		} else if ch >= '0' && ch <= '9' {
-			numStr.WriteByte(byte(ch))
-		} else {
-			return false
-		}
-	}
-
-	// Calculate mod 97 (ISO 7064)
-	num := numStr.String()
-	remainder := 0
-	for _, ch := range num {
-		remainder = (remainder*10 + int(ch-'0')) % 97
-	}
-
-	return remainder == 1
 }

--- a/internal/gleif/identifiers.go
+++ b/internal/gleif/identifiers.go
@@ -1,0 +1,152 @@
+package gleif
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Domain identifier types. These are string-underlying wrappers whose only
+// constructor (Parse*) runs the format validation that the GLEIF API expects.
+// Once a value of one of these types exists, downstream code can interpolate
+// it into a URL or pass it to the API client without re-validating.
+//
+// The validation lives at the MCP boundary: handlers parse caller-supplied
+// strings exactly once, and the rest of the call graph is type-safe. This
+// closes the Primitive Obsession smell that CodeScene flagged on the prior
+// shape (client methods taking bare `string` and re-running the regex check
+// at every call site).
+type (
+	LEI      string
+	BIC      string
+	ISIN     string
+	Country  string
+	IssuerID string
+)
+
+const (
+	leiPattern      = `^[A-Z0-9]{4}[A-Z0-9]{2}[A-Z0-9]{12}[0-9]{2}$`
+	bicPattern      = `^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$`
+	isinPattern     = `^[A-Z]{2}[A-Z0-9]{10}$`
+	countryPattern  = `^[A-Z]{2}$`
+	issuerIDPattern = `^[A-Z0-9]{4,32}$`
+)
+
+var (
+	leiRegex      = regexp.MustCompile(leiPattern)
+	bicRegex      = regexp.MustCompile(bicPattern)
+	isinRegex     = regexp.MustCompile(isinPattern)
+	countryRegex  = regexp.MustCompile(countryPattern)
+	issuerIDRegex = regexp.MustCompile(issuerIDPattern)
+)
+
+// LEIPattern, BICPattern, ISINPattern, CountryPattern, IssuerIDPattern remain
+// exported for external consumers (tests, ToolSpec definitions). They mirror
+// the unexported lowercase constants above.
+const (
+	LEIPattern      = leiPattern
+	BICPattern      = bicPattern
+	ISINPattern     = isinPattern
+	CountryPattern  = countryPattern
+	IssuerIDPattern = issuerIDPattern
+)
+
+// normalize uppercases and trims whitespace. The GLEIF API treats identifiers
+// case-insensitively but rejects whitespace.
+func normalize(s string) string {
+	return strings.ToUpper(strings.TrimSpace(s))
+}
+
+// parseIdentifier is the shared shape behind every Parse* constructor:
+// normalize, reject empty, regex-check, and convert to the target type.
+// Generics let each typed wrapper reuse the body without per-type duplication.
+func parseIdentifier[T ~string](raw, label, formatReason string, re *regexp.Regexp) (T, error) {
+	s := normalize(raw)
+	if s == "" {
+		return "", NewInvalidFormatError(label, "is required")
+	}
+	if !re.MatchString(s) {
+		return "", NewInvalidFormatError(label, formatReason)
+	}
+	return T(s), nil
+}
+
+// ParseLEI validates and constructs an LEI from a caller-supplied string.
+// Format only (regex). Check-digit validation lives on (LEI).HasValidCheckDigits
+// because callers can trust GLEIF's API to reject malformed records, but the
+// validate_lei tool wants to surface check-digit failures explicitly.
+func ParseLEI(s string) (LEI, error) {
+	return parseIdentifier[LEI](s, "LEI", "must be 20 alphanumeric characters", leiRegex)
+}
+
+// ParseBIC validates and constructs a BIC from a caller-supplied string.
+func ParseBIC(s string) (BIC, error) {
+	return parseIdentifier[BIC](s, "BIC", "must be 8 or 11 characters: 4 letters + 2 letters + 2 alphanumeric, optional 3 alphanumeric", bicRegex)
+}
+
+// ParseISIN validates and constructs an ISIN from a caller-supplied string.
+func ParseISIN(s string) (ISIN, error) {
+	return parseIdentifier[ISIN](s, "ISIN", "must be 2 letters followed by 10 alphanumeric characters (12 total)", isinRegex)
+}
+
+// ParseCountry validates and constructs a Country from an ISO 3166-1 alpha-2 code.
+func ParseCountry(s string) (Country, error) {
+	return parseIdentifier[Country](s, "country", "must be a 2-letter ISO 3166-1 alpha-2 code", countryRegex)
+}
+
+// ParseIssuerID validates and constructs an IssuerID. Without this check, an
+// adversarial caller could send issuer_id="../lei-records/SOMELEI" and pivot
+// the URL away from /lei-issuers/ to a different GLEIF endpoint.
+func ParseIssuerID(s string) (IssuerID, error) {
+	return parseIdentifier[IssuerID](s, "issuer_id", "must be 4-32 alphanumeric characters", issuerIDRegex)
+}
+
+// ValidateIssuerID is a thin wrapper kept for backward compatibility with
+// any external caller; new code should use ParseIssuerID.
+func ValidateIssuerID(id string) error {
+	_, err := ParseIssuerID(id)
+	return err
+}
+
+// HasValidCheckDigits validates the ISO 17442 check digits on an LEI.
+// The format-validity precondition (20 chars, alphanumeric) is enforced at
+// construction time by ParseLEI, so this method only re-runs the mod-97 check.
+func (l LEI) HasValidCheckDigits() bool {
+	s := string(l)
+	if len(s) != 20 {
+		return false
+	}
+
+	remainder := 0
+	for _, ch := range s {
+		digit, ok := leiCharToDigit(ch)
+		if !ok {
+			return false
+		}
+		remainder = foldDigit(remainder, digit)
+	}
+	return remainder == 1
+}
+
+// leiCharToDigit maps an LEI character to its mod-97 numeric value.
+// Letters A-Z become 10-35; digits 0-9 keep their value. Anything else is
+// rejected. Extracted from HasValidCheckDigits to flatten the per-character
+// branching that CodeScene flagged as a Complex Conditional.
+func leiCharToDigit(ch rune) (int, bool) {
+	switch {
+	case ch >= 'A' && ch <= 'Z':
+		return int(ch-'A') + 10, true
+	case ch >= '0' && ch <= '9':
+		return int(ch - '0'), true
+	default:
+		return 0, false
+	}
+}
+
+// foldDigit incorporates the next digit into the running mod-97 remainder.
+// Two-digit values (letters) shift by 100; single digits shift by 10.
+func foldDigit(remainder, digit int) int {
+	if digit >= 10 {
+		return (remainder*100 + digit) % 97
+	}
+	return (remainder*10 + digit) % 97
+}

--- a/internal/gleif/validate_paths_test.go
+++ b/internal/gleif/validate_paths_test.go
@@ -1,7 +1,6 @@
 package gleif
 
 import (
-	"context"
 	"strings"
 	"testing"
 )
@@ -63,17 +62,16 @@ func TestValidateIssuerID_AcceptsRealisticIDs(t *testing.T) {
 	}
 }
 
-// TestGetLEIIssuer_RejectsInjectionBeforeHTTP exercises the integrated path
-// through GetLEIIssuer and asserts the validator rejects path-injection
-// payloads before any HTTP request is constructed.
-func TestGetLEIIssuer_RejectsInjectionBeforeHTTP(t *testing.T) {
-	c := &Client{baseURL: "https://example.invalid"}
-
+// TestParseIssuerID_RejectsInjection asserts ParseIssuerID rejects path-
+// injection payloads before any URL is constructed. The typed signature on
+// GetLEIIssuer means a malformed string can't reach the URL builder; the
+// type system enforces what was previously a runtime check.
+func TestParseIssuerID_RejectsInjection(t *testing.T) {
 	maliciousID := "../lei-records/SOMELEI"
-	_, err := c.GetLEIIssuer(context.Background(), maliciousID)
+	_, err := ParseIssuerID(maliciousID)
 
 	if err == nil {
-		t.Fatal("GetLEIIssuer accepted path-injection payload; expected validator rejection")
+		t.Fatal("ParseIssuerID accepted path-injection payload; expected rejection")
 	}
 	if !strings.Contains(err.Error(), "issuer_id") {
 		t.Errorf("error did not mention issuer_id: %v", err)
@@ -83,20 +81,18 @@ func TestGetLEIIssuer_RejectsInjectionBeforeHTTP(t *testing.T) {
 	}
 }
 
-// TestSearchByISIN_QuerySmugglingRejected verifies the ISIN format check
-// blocks payloads that would smuggle additional query parameters via raw
-// fmt.Sprintf interpolation. Even though the URL builder now uses
-// url.Values, the format check is the primary gate.
-func TestSearchByISIN_QuerySmugglingRejected(t *testing.T) {
-	c := newTestClient("https://example.invalid")
-
+// TestParseISIN_QuerySmugglingRejected verifies the ISIN format check blocks
+// payloads that would smuggle additional query parameters. With typed
+// signatures, ParseISIN is the only gate; SearchByISIN can no longer be
+// called with an unparsed string.
+func TestParseISIN_QuerySmugglingRejected(t *testing.T) {
 	// 12-character payload that would have smuggled query params via
 	// the previous fmt.Sprintf path: "X&y=z&w=qABC".
 	smugglingPayload := "X&y=z&w=qABC"
-	_, err := c.SearchByISIN(context.Background(), smugglingPayload)
+	_, err := ParseISIN(smugglingPayload)
 
 	if err == nil {
-		t.Fatal("SearchByISIN accepted smuggling payload; expected validator rejection")
+		t.Fatal("ParseISIN accepted smuggling payload; expected rejection")
 	}
 	if !strings.Contains(err.Error(), "ISIN") {
 		t.Errorf("error did not mention ISIN: %v", err)

--- a/tools/handlers.go
+++ b/tools/handlers.go
@@ -15,8 +15,9 @@ import (
 
 // Registry manages tool registration and handlers.
 type Registry struct {
-	client *gleif.Client
-	logger *slog.Logger
+	client   *gleif.Client
+	logger   *slog.Logger
+	handlers map[string]mcp.ToolHandler
 }
 
 // NewRegistry creates a new tool registry.
@@ -24,9 +25,27 @@ func NewRegistry(client *gleif.Client, logger *slog.Logger) *Registry {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Registry{
-		client: client,
-		logger: logger,
+	r := &Registry{client: client, logger: logger}
+	r.handlers = r.buildHandlerMap()
+	return r
+}
+
+// buildHandlerMap returns the name → handler dispatch table. A map collapses
+// the prior 12-arm switch (cc=13) into a constant-complexity lookup.
+func (r *Registry) buildHandlerMap() map[string]mcp.ToolHandler {
+	return map[string]mcp.ToolHandler{
+		"lei_lookup":               r.handleLEILookup,
+		"validate_lei":             r.handleValidateLEI,
+		"batch_lei_lookup":         r.handleBatchLEILookup,
+		"search_entity":            r.handleSearchEntity,
+		"search_by_bic":            r.handleSearchByBIC,
+		"search_by_isin":           r.handleSearchByISIN,
+		"search_by_country":        r.handleSearchByCountry,
+		"get_relationships":        r.handleGetRelationships,
+		"autocomplete":             r.handleAutocomplete,
+		"get_lei_issuer":           r.handleGetLEIIssuer,
+		"list_lei_issuers":         r.handleListLEIIssuers,
+		"get_reporting_exceptions": r.handleGetReportingExceptions,
 	}
 }
 
@@ -39,54 +58,8 @@ func (r *Registry) RegisterAll(server *mcp.Server) {
 }
 
 func (r *Registry) registerTool(server *mcp.Server, spec ToolSpec) {
-	// Build input schema as map
-	properties := make(map[string]any)
-	required := []string{}
-
-	for _, param := range spec.Parameters {
-		prop := map[string]any{
-			"type":        param.Type,
-			"description": param.Description,
-		}
-		if len(param.Enum) > 0 {
-			prop["enum"] = param.Enum
-		}
-		if param.MinLength != nil {
-			prop["minLength"] = *param.MinLength
-		}
-		if param.MaxLength != nil {
-			prop["maxLength"] = *param.MaxLength
-		}
-		if param.Minimum != nil {
-			prop["minimum"] = *param.Minimum
-		}
-		if param.Maximum != nil {
-			prop["maximum"] = *param.Maximum
-		}
-		if param.Default != nil {
-			prop["default"] = param.Default
-		}
-		if param.Example != nil {
-			prop["examples"] = []any{param.Example}
-		}
-		if param.Pattern != "" {
-			prop["pattern"] = param.Pattern
-		}
-		properties[param.Name] = prop
-		if param.Required {
-			required = append(required, param.Name)
-		}
-	}
-
-	inputSchema := map[string]any{
-		"type":       "object",
-		"properties": properties,
-	}
-	if len(required) > 0 {
-		inputSchema["required"] = required
-	}
-
-	handler := r.getHandler(spec.Name)
+	inputSchema := buildInputSchema(spec.Parameters)
+	handler := r.lookupHandler(spec.Name)
 
 	server.AddTool(&mcp.Tool{
 		Name:        spec.Name,
@@ -100,58 +73,117 @@ func (r *Registry) registerTool(server *mcp.Server, spec ToolSpec) {
 	}, r.wrapHandler(spec.Name, handler))
 }
 
-func (r *Registry) getHandler(name string) mcp.ToolHandler {
-	switch name {
-	case "lei_lookup":
-		return r.handleLEILookup
-	case "validate_lei":
-		return r.handleValidateLEI
-	case "batch_lei_lookup":
-		return r.handleBatchLEILookup
-	case "search_entity":
-		return r.handleSearchEntity
-	case "search_by_bic":
-		return r.handleSearchByBIC
-	case "search_by_isin":
-		return r.handleSearchByISIN
-	case "search_by_country":
-		return r.handleSearchByCountry
-	case "get_relationships":
-		return r.handleGetRelationships
-	case "autocomplete":
-		return r.handleAutocomplete
-	case "get_lei_issuer":
-		return r.handleGetLEIIssuer
-	case "list_lei_issuers":
-		return r.handleListLEIIssuers
-	case "get_reporting_exceptions":
-		return r.handleGetReportingExceptions
-	default:
-		return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			return errorResult(fmt.Sprintf("Unknown tool: %s", name))
+// buildInputSchema converts ParameterSpec slice to MCP input schema map.
+// Extracted from registerTool to drop its cyclomatic complexity below the
+// Go threshold; the per-property field copying is contained here.
+func buildInputSchema(params []ParameterSpec) map[string]any {
+	properties := make(map[string]any, len(params))
+	required := []string{}
+
+	for _, p := range params {
+		properties[p.Name] = buildPropertySchema(p)
+		if p.Required {
+			required = append(required, p.Name)
 		}
+	}
+
+	schema := map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+// buildPropertySchema renders one ParameterSpec as a JSON-Schema property map.
+func buildPropertySchema(p ParameterSpec) map[string]any {
+	prop := map[string]any{
+		"type":        p.Type,
+		"description": p.Description,
+	}
+	if len(p.Enum) > 0 {
+		prop["enum"] = p.Enum
+	}
+	if p.MinLength != nil {
+		prop["minLength"] = *p.MinLength
+	}
+	if p.MaxLength != nil {
+		prop["maxLength"] = *p.MaxLength
+	}
+	if p.Minimum != nil {
+		prop["minimum"] = *p.Minimum
+	}
+	if p.Maximum != nil {
+		prop["maximum"] = *p.Maximum
+	}
+	if p.Default != nil {
+		prop["default"] = p.Default
+	}
+	if p.Example != nil {
+		prop["examples"] = []any{p.Example}
+	}
+	if p.Pattern != "" {
+		prop["pattern"] = p.Pattern
+	}
+	return prop
+}
+
+func (r *Registry) lookupHandler(name string) mcp.ToolHandler {
+	if h, ok := r.handlers[name]; ok {
+		return h
+	}
+	return func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return errorResult(fmt.Sprintf("Unknown tool: %s", name))
 	}
 }
 
 // Handler implementations
+//
+// Single-LEI lookups (lei_lookup, get_relationships, get_reporting_exceptions)
+// share a parse-and-call shape; the lookups that don't need extra args go
+// through handleSimpleLEILookup. Multi-arg handlers below run the parse step
+// inline because the extra arguments diverge.
 
 func (r *Registry) handleLEILookup(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return r.handleSimpleLEILookup(ctx, req, "Failed to fetch LEI", func(ctx context.Context, lei gleif.LEI) (any, error) {
+		return r.client.GetLEI(ctx, lei)
+	})
+}
+
+func (r *Registry) handleGetReportingExceptions(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return r.handleSimpleLEILookup(ctx, req, "Failed to fetch reporting exceptions", func(ctx context.Context, lei gleif.LEI) (any, error) {
+		exceptions, err := r.client.GetReportingExceptions(ctx, lei)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"lei":        string(lei),
+			"count":      len(exceptions),
+			"exceptions": exceptions,
+		}, nil
+	})
+}
+
+func (r *Registry) handleGetLEIIssuer(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args, err := parseArguments(req)
 	if err != nil {
 		return errorResult(err.Error())
 	}
-
-	lei, ok := args["lei"].(string)
-	if !ok || lei == "" {
-		return errorResult("lei parameter is required")
+	id, ok := args["issuer_id"].(string)
+	if !ok || id == "" {
+		return errorResult("issuer_id parameter is required")
 	}
-
-	record, err := r.client.GetLEI(ctx, lei)
+	issuerID, err := gleif.ParseIssuerID(id)
 	if err != nil {
-		return classifyError("Failed to fetch LEI", err)
+		return classifyError("Invalid issuer_id", err)
 	}
-
-	return jsonResult(record)
+	issuer, err := r.client.GetLEIIssuer(ctx, issuerID)
+	if err != nil {
+		return classifyError("Failed to fetch LEI issuer", err)
+	}
+	return jsonResult(issuer)
 }
 
 func (r *Registry) handleValidateLEI(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -159,17 +191,16 @@ func (r *Registry) handleValidateLEI(ctx context.Context, req *mcp.CallToolReque
 	if err != nil {
 		return errorResult(err.Error())
 	}
-
 	lei, ok := args["lei"].(string)
 	if !ok || lei == "" {
 		return errorResult("lei parameter is required")
 	}
-
+	// ValidateLEI accepts raw input on purpose: the tool's job is to report
+	// format/check-digit failures back as validation results.
 	result, err := r.client.ValidateLEI(ctx, lei)
 	if err != nil {
 		return classifyError("Validation error", err)
 	}
-
 	return jsonResult(result)
 }
 
@@ -178,16 +209,14 @@ func (r *Registry) handleBatchLEILookup(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return errorResult(err.Error())
 	}
-
 	leisStr, ok := args["leis"].(string)
 	if !ok || leisStr == "" {
 		return errorResult("leis parameter is required")
 	}
 
-	// Parse comma-separated LEIs
-	leis := strings.Split(leisStr, ",")
-	for i, lei := range leis {
-		leis[i] = strings.TrimSpace(lei)
+	leis, parseErr := parseBatchLEIs(leisStr)
+	if parseErr != nil {
+		return classifyError("Invalid LEI in batch", parseErr)
 	}
 
 	records, err := r.client.GetBatchLEI(ctx, leis)
@@ -195,39 +224,53 @@ func (r *Registry) handleBatchLEILookup(ctx context.Context, req *mcp.CallToolRe
 		return classifyError("Batch lookup failed", err)
 	}
 
-	// Return simplified results
+	return jsonResult(buildBatchResponse(leis, records))
+}
+
+// parseBatchLEIs splits the comma-separated input and parses each entry.
+// Returns the first parse error so the caller can surface it.
+func parseBatchLEIs(raw string) ([]gleif.LEI, error) {
+	parts := strings.Split(raw, ",")
+	leis := make([]gleif.LEI, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		lei, err := gleif.ParseLEI(part)
+		if err != nil {
+			return nil, err
+		}
+		leis = append(leis, lei)
+	}
+	return leis, nil
+}
+
+// buildBatchResponse shapes the batch results, including the not-found set.
+func buildBatchResponse(requested []gleif.LEI, records []gleif.LEIRecord) map[string]any {
 	results := make([]map[string]any, len(records))
 	foundLEIs := make(map[string]bool, len(records))
 	for i, rec := range records {
-		results[i] = map[string]any{
-			"lei":       rec.LEI,
-			"legalName": rec.Entity.LegalName.Name,
-			"country":   rec.Entity.LegalAddress.Country,
-			"city":      rec.Entity.LegalAddress.City,
-			"status":    rec.Entity.Status,
-			"regStatus": rec.Registration.Status,
-		}
+		results[i] = simplifyRecord(rec)
 		foundLEIs[rec.LEI] = true
 	}
 
-	// Compute set difference: requested LEIs not in results
 	var notFound []string
-	for _, lei := range leis {
-		if !foundLEIs[lei] {
-			notFound = append(notFound, lei)
+	for _, lei := range requested {
+		if !foundLEIs[string(lei)] {
+			notFound = append(notFound, string(lei))
 		}
 	}
 
 	response := map[string]any{
-		"requested": len(leis),
+		"requested": len(requested),
 		"found":     len(results),
 		"results":   results,
 	}
 	if len(notFound) > 0 {
 		response["notFound"] = notFound
 	}
-
-	return jsonResult(response)
+	return response
 }
 
 func (r *Registry) handleSearchEntity(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -235,61 +278,40 @@ func (r *Registry) handleSearchEntity(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		return errorResult(err.Error())
 	}
-
 	query, ok := args["query"].(string)
 	if !ok || query == "" {
 		return errorResult("query parameter is required")
 	}
 
-	limit := 20
-	if l, ok := args["limit"].(float64); ok {
-		limit = int(l)
-	}
+	limit := intArg(args, "limit", 20)
+	page := intArg(args, "page", 1)
+	fuzzy := boolArg(args, "fuzzy", true)
 
-	page := 1
-	if p, ok := args["page"].(float64); ok {
-		page = int(p)
-	}
-
-	// Default to fuzzy search
-	fuzzy := true
-	if f, ok := args["fuzzy"].(bool); ok {
-		fuzzy = f
-	}
-
-	var records []gleif.LEIRecord
-	var pagination *gleif.Pagination
-	var searchErr error
-
-	if fuzzy {
-		records, pagination, searchErr = r.client.FuzzySearch(ctx, query, limit, page)
-	} else {
-		records, pagination, searchErr = r.client.SearchEntities(ctx, query, limit, page)
-	}
-
+	records, pagination, searchErr := r.executeSearch(ctx, query, limit, page, fuzzy)
 	if searchErr != nil {
 		return classifyError("Search failed", searchErr)
 	}
 
-	// Return simplified results
+	return jsonResult(buildSearchResponse(records, pagination))
+}
+
+// executeSearch picks the search backend based on the fuzzy flag.
+func (r *Registry) executeSearch(ctx context.Context, query string, limit, page int, fuzzy bool) ([]gleif.LEIRecord, *gleif.Pagination, error) {
+	if fuzzy {
+		return r.client.FuzzySearch(ctx, query, limit, page)
+	}
+	return r.client.SearchEntities(ctx, query, limit, page)
+}
+
+func buildSearchResponse(records []gleif.LEIRecord, pagination *gleif.Pagination) map[string]any {
 	results := make([]map[string]any, len(records))
 	for i, rec := range records {
-		results[i] = map[string]any{
-			"lei":       rec.LEI,
-			"legalName": rec.Entity.LegalName.Name,
-			"country":   rec.Entity.LegalAddress.Country,
-			"city":      rec.Entity.LegalAddress.City,
-			"status":    rec.Entity.Status,
-			"regStatus": rec.Registration.Status,
-		}
+		results[i] = simplifyRecord(rec)
 	}
-
 	response := map[string]any{
 		"count":   len(results),
 		"results": results,
 	}
-
-	// Add pagination info if available
 	if pagination != nil {
 		response["pagination"] = map[string]any{
 			"currentPage": pagination.CurrentPage,
@@ -299,8 +321,7 @@ func (r *Registry) handleSearchEntity(ctx context.Context, req *mcp.CallToolRequ
 		}
 		response["hasMore"] = pagination.CurrentPage < pagination.LastPage
 	}
-
-	return jsonResult(response)
+	return response
 }
 
 func (r *Registry) handleSearchByBIC(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -308,31 +329,19 @@ func (r *Registry) handleSearchByBIC(ctx context.Context, req *mcp.CallToolReque
 	if err != nil {
 		return errorResult(err.Error())
 	}
-
-	bic, ok := args["bic"].(string)
-	if !ok || bic == "" {
+	raw, ok := args["bic"].(string)
+	if !ok || raw == "" {
 		return errorResult("bic parameter is required")
 	}
-
+	bic, err := gleif.ParseBIC(raw)
+	if err != nil {
+		return classifyError("Invalid BIC", err)
+	}
 	records, err := r.client.SearchByBIC(ctx, bic)
 	if err != nil {
 		return classifyError("BIC search failed", err)
 	}
-
-	if len(records) == 0 {
-		return jsonResult(map[string]any{
-			"found":   false,
-			"count":   0,
-			"records": []any{},
-			"message": "No LEI found for this BIC code",
-		})
-	}
-
-	return jsonResult(map[string]any{
-		"found":   true,
-		"count":   len(records),
-		"records": records,
-	})
+	return jsonResult(buildIDSearchResponse(records, "No LEI found for this BIC code"))
 }
 
 func (r *Registry) handleSearchByISIN(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -340,31 +349,38 @@ func (r *Registry) handleSearchByISIN(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		return errorResult(err.Error())
 	}
-
-	isin, ok := args["isin"].(string)
-	if !ok || isin == "" {
+	raw, ok := args["isin"].(string)
+	if !ok || raw == "" {
 		return errorResult("isin parameter is required")
 	}
-
+	isin, err := gleif.ParseISIN(raw)
+	if err != nil {
+		return classifyError("Invalid ISIN", err)
+	}
 	records, err := r.client.SearchByISIN(ctx, isin)
 	if err != nil {
 		return classifyError("ISIN search failed", err)
 	}
+	return jsonResult(buildIDSearchResponse(records, "No issuer LEI found for this ISIN"))
+}
 
+// buildIDSearchResponse shapes BIC/ISIN search results uniformly. Replaces
+// the duplicate found/empty branches that CodeScene flagged across both
+// handlers.
+func buildIDSearchResponse(records []gleif.LEIRecord, emptyMessage string) map[string]any {
 	if len(records) == 0 {
-		return jsonResult(map[string]any{
+		return map[string]any{
 			"found":   false,
 			"count":   0,
 			"records": []any{},
-			"message": "No issuer LEI found for this ISIN",
-		})
+			"message": emptyMessage,
+		}
 	}
-
-	return jsonResult(map[string]any{
+	return map[string]any{
 		"found":   true,
 		"count":   len(records),
 		"records": records,
-	})
+	}
 }
 
 func (r *Registry) handleSearchByCountry(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -372,23 +388,21 @@ func (r *Registry) handleSearchByCountry(ctx context.Context, req *mcp.CallToolR
 	if err != nil {
 		return errorResult(err.Error())
 	}
-
-	country, ok := args["country"].(string)
-	if !ok || country == "" {
+	raw, ok := args["country"].(string)
+	if !ok || raw == "" {
 		return errorResult("country parameter is required")
 	}
-
-	limit := 20
-	if l, ok := args["limit"].(float64); ok {
-		limit = int(l)
+	country, err := gleif.ParseCountry(raw)
+	if err != nil {
+		return classifyError("Invalid country", err)
 	}
 
+	limit := intArg(args, "limit", 20)
 	records, err := r.client.SearchByCountry(ctx, country, limit)
 	if err != nil {
 		return classifyError("Country search failed", err)
 	}
 
-	// Return simplified results
 	results := make([]map[string]any, len(records))
 	for i, rec := range records {
 		results[i] = map[string]any{
@@ -398,9 +412,8 @@ func (r *Registry) handleSearchByCountry(ctx context.Context, req *mcp.CallToolR
 			"status":    rec.Entity.Status,
 		}
 	}
-
 	return jsonResult(map[string]any{
-		"country": country,
+		"country": string(country),
 		"count":   len(results),
 		"results": results,
 	})
@@ -411,10 +424,13 @@ func (r *Registry) handleGetRelationships(ctx context.Context, req *mcp.CallTool
 	if err != nil {
 		return errorResult(err.Error())
 	}
-
-	lei, ok := args["lei"].(string)
-	if !ok || lei == "" {
+	raw, ok := args["lei"].(string)
+	if !ok || raw == "" {
 		return errorResult("lei parameter is required")
+	}
+	lei, err := gleif.ParseLEI(raw)
+	if err != nil {
+		return classifyError("Invalid LEI", err)
 	}
 
 	relType := "direct-parent"
@@ -428,7 +444,7 @@ func (r *Registry) handleGetRelationships(ctx context.Context, req *mcp.CallTool
 	}
 
 	return jsonResult(map[string]any{
-		"lei":           lei,
+		"lei":           string(lei),
 		"type":          relType,
 		"relationships": relationships,
 	})
@@ -439,17 +455,12 @@ func (r *Registry) handleAutocomplete(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		return errorResult(err.Error())
 	}
-
 	prefix, ok := args["prefix"].(string)
 	if !ok || prefix == "" {
 		return errorResult("prefix parameter is required")
 	}
 
-	limit := 10
-	if l, ok := args["limit"].(float64); ok {
-		limit = int(l)
-	}
-
+	limit := intArg(args, "limit", 10)
 	suggestions, err := r.client.Autocomplete(ctx, prefix, limit)
 	if err != nil {
 		return classifyError("Autocomplete failed", err)
@@ -461,61 +472,77 @@ func (r *Registry) handleAutocomplete(ctx context.Context, req *mcp.CallToolRequ
 	})
 }
 
-func (r *Registry) handleGetLEIIssuer(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, err := parseArguments(req)
-	if err != nil {
-		return errorResult(err.Error())
-	}
-
-	issuerID, ok := args["issuer_id"].(string)
-	if !ok || issuerID == "" {
-		return errorResult("issuer_id parameter is required")
-	}
-
-	issuer, err := r.client.GetLEIIssuer(ctx, issuerID)
-	if err != nil {
-		return classifyError("Failed to fetch LEI issuer", err)
-	}
-
-	return jsonResult(issuer)
-}
-
-func (r *Registry) handleListLEIIssuers(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (r *Registry) handleListLEIIssuers(ctx context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	issuers, err := r.client.ListLEIIssuers(ctx)
 	if err != nil {
 		return classifyError("Failed to list LEI issuers", err)
 	}
-
 	return jsonResult(map[string]any{
 		"count":   len(issuers),
 		"issuers": issuers,
 	})
 }
 
-func (r *Registry) handleGetReportingExceptions(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// Helpers
+
+// handleSimpleLEILookup is the shared shape for handlers whose only argument
+// is an LEI: parse args, parse the LEI, call the client, format the response.
+// Replaces the duplicate prologue across handleLEILookup, handleGetReporting-
+// Exceptions (and previously handleGetRelationships before it grew an extra arg).
+func (r *Registry) handleSimpleLEILookup(
+	ctx context.Context,
+	req *mcp.CallToolRequest,
+	errorPrefix string,
+	call func(context.Context, gleif.LEI) (any, error),
+) (*mcp.CallToolResult, error) {
 	args, err := parseArguments(req)
 	if err != nil {
 		return errorResult(err.Error())
 	}
-
-	lei, ok := args["lei"].(string)
-	if !ok || lei == "" {
+	raw, ok := args["lei"].(string)
+	if !ok || raw == "" {
 		return errorResult("lei parameter is required")
 	}
-
-	exceptions, err := r.client.GetReportingExceptions(ctx, lei)
+	lei, err := gleif.ParseLEI(raw)
 	if err != nil {
-		return classifyError("Failed to fetch reporting exceptions", err)
+		return classifyError("Invalid LEI", err)
 	}
-
-	return jsonResult(map[string]any{
-		"lei":        lei,
-		"count":      len(exceptions),
-		"exceptions": exceptions,
-	})
+	result, err := call(ctx, lei)
+	if err != nil {
+		return classifyError(errorPrefix, err)
+	}
+	return jsonResult(result)
 }
 
-// Helper functions
+// simplifyRecord builds the trimmed-down representation used by batch and
+// search responses. Centralized to keep the field list in one place.
+func simplifyRecord(rec gleif.LEIRecord) map[string]any {
+	return map[string]any{
+		"lei":       rec.LEI,
+		"legalName": rec.Entity.LegalName.Name,
+		"country":   rec.Entity.LegalAddress.Country,
+		"city":      rec.Entity.LegalAddress.City,
+		"status":    rec.Entity.Status,
+		"regStatus": rec.Registration.Status,
+	}
+}
+
+// intArg pulls an int argument out of MCP's float64-typed JSON, falling back
+// to the supplied default if missing or wrong-typed.
+func intArg(args map[string]any, name string, def int) int {
+	if v, ok := args[name].(float64); ok {
+		return int(v)
+	}
+	return def
+}
+
+// boolArg pulls a bool argument with a fallback default.
+func boolArg(args map[string]any, name string, def bool) bool {
+	if v, ok := args[name].(bool); ok {
+		return v
+	}
+	return def
+}
 
 func parseArguments(req *mcp.CallToolRequest) (map[string]any, error) {
 	if len(req.Params.Arguments) == 0 {
@@ -534,11 +561,7 @@ func jsonResult(data any) (*mcp.CallToolResult, error) {
 		return nil, fmt.Errorf("failed to marshal result: %w", err)
 	}
 	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{
-				Text: string(jsonBytes),
-			},
-		},
+		Content: []mcp.Content{&mcp.TextContent{Text: string(jsonBytes)}},
 	}, nil
 }
 
@@ -554,11 +577,7 @@ func errorResultWithCode(code, message string, retryable bool) (*mcp.CallToolRes
 		"retryable": retryable,
 	}, "", "  ")
 	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{
-				Text: string(errJSON),
-			},
-		},
+		Content: []mcp.Content{&mcp.TextContent{Text: string(errJSON)}},
 		IsError: true,
 	}, nil
 }

--- a/tools/handlers_test.go
+++ b/tools/handlers_test.go
@@ -866,9 +866,9 @@ func TestGetHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := registry.getHandler(tt.toolName)
+			handler := registry.lookupHandler(tt.toolName)
 			if handler == nil && !tt.wantNil {
-				t.Errorf("getHandler(%q) returned nil", tt.toolName)
+				t.Errorf("lookupHandler(%q) returned nil", tt.toolName)
 			}
 		})
 	}
@@ -877,7 +877,7 @@ func TestGetHandler(t *testing.T) {
 // TestUnknownToolHandler tests that unknown tools return an error.
 func TestUnknownToolHandler(t *testing.T) {
 	registry := newTestRegistry("http://unused")
-	handler := registry.getHandler("nonexistent_tool")
+	handler := registry.lookupHandler("nonexistent_tool")
 	req := makeRequest(map[string]any{})
 
 	result, err := handler(context.Background(), req)


### PR DESCRIPTION
## Summary

- Lift `internal/gleif/client.go` from **6.87 → 9.92** and `tools/handlers.go` from **7.83 → 9.38** by introducing typed identifier wrappers, decomposing complex methods, and extracting handler-side helpers.
- New `internal/gleif/identifiers.go` (9.68) holds `LEI`, `BIC`, `ISIN`, `Country`, `IssuerID` types with `Parse*` constructors. Validation moves from runtime regex prologues in client methods into the type system at the MCP boundary.
- Behavioral surface unchanged: every MCP tool name, argument, and response shape is identical. Path-injection regression tests now exercise `ParseIssuerID`/`ParseISIN` directly because the type system enforces the invariant the old runtime checks defended.

## Code Health re-score

| File                          | Before | After | Tier |
|-------------------------------|--------|-------|------|
| `internal/gleif/client.go`    | 6.87   | 9.92  | almost Optimal |
| `tools/handlers.go`           | 7.83   | 9.38  | Green |
| `internal/gleif/identifiers.go` | (new)  | 9.68  | Green |
| `internal/gleif/cache.go`     | 9.09   | 9.09  | Green (untouched) |
| `tools/definitions.go`        | 10     | 10    | Optimal |
| `internal/gleif/errors.go`    | 10     | 10    | Optimal |
| `main.go`                     | 10     | 10    | Optimal |

CodeScene's `code_health_refactoring_business_case` projected `client.go` needed 9.1 to enter the top-5% bracket; we landed at 9.92, exceeding the optimistic outcome (defects -27 to -41%, time -21 to -33% over the prior shape).

## Smells closed

`client.go` (6.87 baseline):
- Low Cohesion (LCOM4) — package-level `ValidateIssuerID`, `validateLEICheckDigits` no longer live alongside Client methods.
- Bumpy Road on `Autocomplete`, `doRequest` — extracted `fuzzyAutocompleteFallback`, `executeAndRead`, `mapStatusToError`.
- Complex Method on `GetRelationships` (cc=12), `validateLEICheckDigits` (cc=10), `doRequest` (cc=10), `GetBatchLEI` (cc=10), `Autocomplete` (cc=9), `FuzzySearch` (cc=9) — all decomposed; check-digit logic moved into `(LEI).HasValidCheckDigits` + `leiCharToDigit` + `foldDigit`.
- Primitive Obsession (55% of args) — typed wrappers consume the bulk of LEI/BIC/ISIN/Country/IssuerID surface.
- String Heavy (40% of args) — same fix.

`handlers.go` (7.83 baseline):
- Complex Method on `getHandler` (cc=13) — replaced with map dispatch.
- Complex Method on `registerTool` (cc=12) — extracted `buildInputSchema` + `buildPropertySchema`.
- Complex Method on `handleSearchEntity` (cc=12), `handleBatchLEILookup` (cc=10) — extracted `executeSearch`, `buildSearchResponse`, `parseBatchLEIs`, `buildBatchResponse`.
- Code Duplication across `handleLEILookup`/`handleValidateLEI`/`handleSearchByBIC`/`handleSearchByISIN`/`handleGetLEIIssuer` — extracted `handleSimpleLEILookup` and `buildIDSearchResponse`.

## Test plan

- [x] `go test -race -failfast ./...` passes (1.31s gleif + 1.36s tools)
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `code_health_score` ≥ 9.0 on every source file
- [x] All path-injection / query-smuggling / cache-isolation / singleflight regression tests pass
- [ ] CI green on push (matrix builds, vuln-check, security scans)

## Diff stat

```
 internal/gleif/client.go              | 637 +++++++++++++++-------------------
 internal/gleif/client_test.go         | 113 +++---
 internal/gleif/identifiers.go         | 152 ++++++++
 internal/gleif/validate_paths_test.go |  32 +-
 tools/handlers.go                     | 511 ++++++++++++++-------------
 tools/handlers_test.go                |   6 +-
 6 files changed, 781 insertions(+), 670 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)