### PR TITLE
refactor(codescene): lift code health scores

### DIFF
--- a/internal/gleif/cache.go
+++ b/internal/gleif/cache.go
@@ -118,37 +118,67 @@ func NewCache(config CacheConfig) (*Cache, error) {
 	}, nil
 }
 
-// GetLEI retrieves a cached LEI record. Returns a deep copy so callers can
-// freely mutate without affecting the cache or other concurrent callers.
-func (c *Cache) GetLEI(lei string) (*LEIRecord, bool) {
-	if !c.config.Enabled || c.leiCache == nil {
-		return nil, false
-	}
-
-	entry, ok := c.leiCache.Get(lei)
-	if !ok || entry.isExpired() {
-		c.mu.Lock()
-		c.stats.Misses++
-		c.mu.Unlock()
-		if ok {
-			c.leiCache.Remove(lei)
-		}
-		return nil, false
-	}
-
-	out, err := cloneLEIRecord(entry.value)
-	if err != nil || out == nil {
-		// Treat clone failure as a cache miss rather than risk handing
-		// the shared pointer back to the caller.
-		c.mu.Lock()
-		c.stats.Misses++
-		c.mu.Unlock()
-		return nil, false
-	}
-
+// recordHit and recordMiss centralize the locked counter updates used by
+// every Get* method on the cache.
+func (c *Cache) recordHit() {
 	c.mu.Lock()
 	c.stats.Hits++
 	c.mu.Unlock()
+}
+
+func (c *Cache) recordMiss() {
+	c.mu.Lock()
+	c.stats.Misses++
+	c.mu.Unlock()
+}
+
+// lookupEntry performs the shared "check enabled, fetch, expire-check, count"
+// flow for every typed cache. It returns the stored value and ok=true on a
+// hit. On a miss (disabled cache, absent key, or expired entry) it bumps the
+// miss counter, evicts any stale entry, and returns the zero value with
+// ok=false.
+//
+// Because Go generics don't allow methods to be generic, this is a package-
+// level function taking the cache, the typed LRU, and the key.
+func lookupEntry[T any](
+	c *Cache,
+	store *lru.Cache[string, cacheEntry[T]],
+	key string,
+) (T, bool) {
+	var zero T
+	if !c.config.Enabled || store == nil {
+		return zero, false
+	}
+
+	entry, ok := store.Get(key)
+	if !ok || entry.isExpired() {
+		c.recordMiss()
+		if ok {
+			store.Remove(key)
+		}
+		return zero, false
+	}
+
+	return entry.value, true
+}
+
+// GetLEI retrieves a cached LEI record. Returns a deep copy so callers can
+// freely mutate without affecting the cache or other concurrent callers.
+func (c *Cache) GetLEI(lei string) (*LEIRecord, bool) {
+	value, ok := lookupEntry(c, c.leiCache, lei)
+	if !ok {
+		return nil, false
+	}
+
+	out, err := cloneLEIRecord(value)
+	if err != nil || out == nil {
+		// Treat clone failure as a cache miss rather than risk handing
+		// the shared pointer back to the caller.
+		c.recordMiss()
+		return nil, false
+	}
+
+	c.recordHit()
 	return out, true
 }
 
@@ -173,25 +203,12 @@ func (c *Cache) SetLEI(lei string, record *LEIRecord) {
 
 // GetValidation retrieves a cached validation result.
 func (c *Cache) GetValidation(lei string) (*ValidationResult, bool) {
-	if !c.config.Enabled || c.validCache == nil {
+	value, ok := lookupEntry(c, c.validCache, lei)
+	if !ok {
 		return nil, false
 	}
-
-	entry, ok := c.validCache.Get(lei)
-	if !ok || entry.isExpired() {
-		c.mu.Lock()
-		c.stats.Misses++
-		c.mu.Unlock()
-		if ok {
-			c.validCache.Remove(lei)
-		}
-		return nil, false
-	}
-
-	c.mu.Lock()
-	c.stats.Hits++
-	c.mu.Unlock()
-	return entry.value, true
+	c.recordHit()
+	return value, true
 }
 
 // SetValidation caches a validation result.
@@ -208,25 +225,12 @@ func (c *Cache) SetValidation(lei string, result *ValidationResult) {
 
 // GetSearch retrieves cached search results.
 func (c *Cache) GetSearch(key string) ([]LEIRecord, bool) {
-	if !c.config.Enabled || c.searchCache == nil {
+	value, ok := lookupEntry(c, c.searchCache, key)
+	if !ok {
 		return nil, false
 	}
-
-	entry, ok := c.searchCache.Get(key)
-	if !ok || entry.isExpired() {
-		c.mu.Lock()
-		c.stats.Misses++
-		c.mu.Unlock()
-		if ok {
-			c.searchCache.Remove(key)
-		}
-		return nil, false
-	}
-
-	c.mu.Lock()
-	c.stats.Hits++
-	c.mu.Unlock()
-	return entry.value, true
+	c.recordHit()
+	return value, true
 }
 
 // SetSearch caches search results.
@@ -243,25 +247,12 @@ func (c *Cache) SetSearch(key string, records []LEIRecord) {
 
 // GetAutocomplete retrieves cached autocomplete results.
 func (c *Cache) GetAutocomplete(prefix string) ([]AutocompleteResult, bool) {
-	if !c.config.Enabled || c.autoCache == nil {
+	value, ok := lookupEntry(c, c.autoCache, prefix)
+	if !ok {
 		return nil, false
 	}
-
-	entry, ok := c.autoCache.Get(prefix)
-	if !ok || entry.isExpired() {
-		c.mu.Lock()
-		c.stats.Misses++
-		c.mu.Unlock()
-		if ok {
-			c.autoCache.Remove(prefix)
-		}
-		return nil, false
-	}
-
-	c.mu.Lock()
-	c.stats.Hits++
-	c.mu.Unlock()
-	return entry.value, true
+	c.recordHit()
+	return value, true
 }
 
 // SetAutocomplete caches autocomplete results.

--- a/internal/gleif/client.go
+++ b/internal/gleif/client.go
@@ -113,28 +113,43 @@ func (c *Client) doRequestWithRetry(ctx context.Context, url string, result any)
 	var lastErr error
 
 	for attempt := 0; attempt <= c.config.MaxRetries; attempt++ {
-		if err := c.limiter.Wait(ctx); err != nil {
-			return NewRateLimitError(60)
-		}
-
-		err := c.doRequest(ctx, url, result)
-		if err == nil {
-			return nil
-		}
-
-		lastErr = err
-		if !IsRetryable(err) {
+		done, err := c.tryRequest(ctx, attempt, url, result)
+		if done {
 			return err
 		}
-
-		if attempt < c.config.MaxRetries {
-			if waitErr := c.waitForRetry(ctx, attempt, err); waitErr != nil {
-				return waitErr
-			}
-		}
+		lastErr = err
 	}
 
 	return lastErr
+}
+
+// tryRequest performs one attempt of doRequestWithRetry. It returns done=true
+// when the caller should stop iterating (either success or a terminal error)
+// and done=false plus the underlying retryable error when another iteration
+// should run. The retry backoff is handled here so the caller stays linear.
+func (c *Client) tryRequest(ctx context.Context, attempt int, url string, result any) (bool, error) {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return true, NewRateLimitError(60)
+	}
+
+	err := c.doRequest(ctx, url, result)
+	if err == nil {
+		return true, nil
+	}
+
+	if !IsRetryable(err) {
+		return true, err
+	}
+
+	if attempt >= c.config.MaxRetries {
+		return false, err
+	}
+
+	if waitErr := c.waitForRetry(ctx, attempt, err); waitErr != nil {
+		return true, waitErr
+	}
+
+	return false, err
 }
 
 // waitForRetry sleeps with exponential backoff and respects context cancellation.

--- a/tools/handlers.go
+++ b/tools/handlers.go
@@ -103,31 +103,51 @@ func buildPropertySchema(p ParameterSpec) map[string]any {
 		"type":        p.Type,
 		"description": p.Description,
 	}
-	if len(p.Enum) > 0 {
-		prop["enum"] = p.Enum
-	}
+	addLengthBounds(prop, p)
+	addNumericBounds(prop, p)
+	addEnumAndExample(prop, p)
+	addDefaultAndPattern(prop, p)
+	return prop
+}
+
+// addLengthBounds copies MinLength / MaxLength into the property map when set.
+func addLengthBounds(prop map[string]any, p ParameterSpec) {
 	if p.MinLength != nil {
 		prop["minLength"] = *p.MinLength
 	}
 	if p.MaxLength != nil {
 		prop["maxLength"] = *p.MaxLength
 	}
+}
+
+// addNumericBounds copies Minimum / Maximum into the property map when set.
+func addNumericBounds(prop map[string]any, p ParameterSpec) {
 	if p.Minimum != nil {
 		prop["minimum"] = *p.Minimum
 	}
 	if p.Maximum != nil {
 		prop["maximum"] = *p.Maximum
 	}
-	if p.Default != nil {
-		prop["default"] = p.Default
+}
+
+// addEnumAndExample copies enum and example values into the property map.
+func addEnumAndExample(prop map[string]any, p ParameterSpec) {
+	if len(p.Enum) > 0 {
+		prop["enum"] = p.Enum
 	}
 	if p.Example != nil {
 		prop["examples"] = []any{p.Example}
 	}
+}
+
+// addDefaultAndPattern copies Default and Pattern into the property map.
+func addDefaultAndPattern(prop map[string]any, p ParameterSpec) {
+	if p.Default != nil {
+		prop["default"] = p.Default
+	}
 	if p.Pattern != "" {
 		prop["pattern"] = p.Pattern
 	}
-	return prop
 }
 
 func (r *Registry) lookupHandler(name string) mcp.ToolHandler {
@@ -287,7 +307,12 @@ func (r *Registry) handleSearchEntity(ctx context.Context, req *mcp.CallToolRequ
 	page := intArg(args, "page", 1)
 	fuzzy := boolArg(args, "fuzzy", true)
 
-	records, pagination, searchErr := r.executeSearch(ctx, query, limit, page, fuzzy)
+	records, pagination, searchErr := r.executeSearch(ctx, searchRequest{
+		query: query,
+		limit: limit,
+		page:  page,
+		fuzzy: fuzzy,
+	})
 	if searchErr != nil {
 		return classifyError("Search failed", searchErr)
 	}
@@ -295,12 +320,21 @@ func (r *Registry) handleSearchEntity(ctx context.Context, req *mcp.CallToolRequ
 	return jsonResult(buildSearchResponse(records, pagination))
 }
 
+// searchRequest groups parameters for executeSearch. Keeping them together
+// avoids the long argument list that codescene flagged.
+type searchRequest struct {
+	query string
+	limit int
+	page  int
+	fuzzy bool
+}
+
 // executeSearch picks the search backend based on the fuzzy flag.
-func (r *Registry) executeSearch(ctx context.Context, query string, limit, page int, fuzzy bool) ([]gleif.LEIRecord, *gleif.Pagination, error) {
-	if fuzzy {
-		return r.client.FuzzySearch(ctx, query, limit, page)
+func (r *Registry) executeSearch(ctx context.Context, req searchRequest) ([]gleif.LEIRecord, *gleif.Pagination, error) {
+	if req.fuzzy {
+		return r.client.FuzzySearch(ctx, req.query, req.limit, req.page)
 	}
-	return r.client.SearchEntities(ctx, query, limit, page)
+	return r.client.SearchEntities(ctx, req.query, req.limit, req.page)
 }
 
 func buildSearchResponse(records []gleif.LEIRecord, pagination *gleif.Pagination) map[string]any {


### PR DESCRIPTION
## Summary

Manual-mode codescene refactor pass — indication-3 findings cleared via pure helper extraction, behavior preserved. Tests + lint green locally.

Part of experiment bead `claude-code-config-k5x` (Carlini-style parallel agent pattern applied to portfolio-wide code quality work). Sibling PRs merged the same way across the MCP portfolio on 2026-05-17.

## Verification

- `go test ./...` clean (or `tsc --noEmit` for the one TS repo)
- `golangci-lint run ./...` clean where installed
- No tool schemas, error strings, retry timing, or response shapes changed
- codescene `analyze_change_set` vs main: `quality_gates: passed`

## Refs

- Rollup: vault note `MCP Portfolio Codescene Refactor 17-05-2026`
- Bead: `claude-code-config-k5x`
- Per-repo report: `/tmp/k5x-codescene/<repo>.md` (where available)