### PR TITLE
ci: drop binary upload from ci.yml (saves Free-tier Actions storage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,6 @@ jobs:
           if [ "$GOOS" = "windows" ]; then ext=".exe"; fi
           go build -ldflags="-s -w" -o gleif-mcp-server-${GOOS}-${GOARCH}${ext} .
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: gleif-mcp-server-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: gleif-mcp-server-*
-
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Removes the `upload-artifact` step from `ci.yml` build matrix; the build step itself stays as a cross-compile smoke test (still catches darwin/linux/windows breakage at compile time)
- `release.yml` is untouched — tagged releases still produce and upload downloadable binaries
- Recovers GitHub Actions storage on Free tier (500 MB cap); these CI-upload artifacts had no consumer

## Why
Cross-platform binaries uploaded on every push and PR with the default 90-day retention. Across the MCP server portfolio, ci.yml uploads were the dominant consumer of the Free-tier 500 MB storage budget. `release.yml` is independent and handles the real downloadable binaries on tagged releases.

## Test plan
- [x] YAML still parses (verified locally with `python3 -c "yaml.safe_load(...)"`)
- [ ] CI passes on this branch (test + lint + build matrix still run; nothing depends on the removed upload step)
- [ ] No external workflow consumed these ci.yml artifacts (manual confirm — release.yml is independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)