### PR TITLE
refactor(tools): migrate 12 read-only tools to generic AddTool[Args,Result]

### DIFF
--- a/tools/args.go
+++ b/tools/args.go
@@ -1,0 +1,172 @@
+package tools
+
+import "github.com/olgasafonova/gleif-mcp-server/internal/gleif"
+
+// This file defines the typed Args and Result structs that drive schema
+// generation under the generic mcp.AddTool[Args, Result] registration path
+// (see registry.go). The go-sdk derives the input schema from the Args struct
+// and the output schema + structuredContent from the Result struct.
+//
+// Tag convention (verified against google/jsonschema-go v0.4.3, which the
+// go-sdk uses): a field is REQUIRED unless it carries `,omitempty`; the
+// `jsonschema:"..."` tag value becomes the property description. (Note: the
+// `jsonschema_description` tag used by some sibling servers is NOT read by this
+// library — it silently no-ops, and `jsonschema:"required"` sets the
+// description to the literal word "required". This file uses the convention
+// the library actually honours.) Format/range/enum constraints are enforced in
+// the handlers via the gleif.Parse* validators and default clamping, and
+// described in the tag text, since the library does not derive them from tags.
+
+// --- Args structs (one per tool) ---
+
+// LEILookupArgs are the arguments for lei_lookup.
+type LEILookupArgs struct {
+	LEI string `json:"lei" jsonschema:"20-character LEI code, e.g. HWUPKR0MPOU8FGXBT394"`
+}
+
+// ValidateLEIArgs are the arguments for validate_lei.
+type ValidateLEIArgs struct {
+	LEI string `json:"lei" jsonschema:"LEI code to validate. Any format is accepted; the tool reports valid=false rather than erroring"`
+}
+
+// BatchLEIArgs are the arguments for batch_lei_lookup.
+type BatchLEIArgs struct {
+	LEIs string `json:"leis" jsonschema:"Comma-separated LEI codes (max 100), e.g. HWUPKR0MPOU8FGXBT394,7LTWFZYICNSX8D621K86"`
+}
+
+// SearchEntityArgs are the arguments for search_entity.
+type SearchEntityArgs struct {
+	Query string `json:"query" jsonschema:"Company name to search"`
+	Limit int    `json:"limit,omitempty" jsonschema:"Max results per page, 1-100 (default 20)"`
+	Page  int    `json:"page,omitempty" jsonschema:"Page number, minimum 1 (default 1)"`
+	Fuzzy *bool  `json:"fuzzy,omitempty" jsonschema:"Use fuzzy matching (default true)"`
+}
+
+// SearchByBICArgs are the arguments for search_by_bic.
+type SearchByBICArgs struct {
+	BIC string `json:"bic" jsonschema:"BIC/SWIFT code, 8 or 11 characters, e.g. DEUTDEFF"`
+}
+
+// SearchByISINArgs are the arguments for search_by_isin.
+type SearchByISINArgs struct {
+	ISIN string `json:"isin" jsonschema:"12-character ISIN code, e.g. US0378331005"`
+}
+
+// SearchByCountryArgs are the arguments for search_by_country.
+type SearchByCountryArgs struct {
+	Country string `json:"country" jsonschema:"2-letter ISO 3166-1 alpha-2 country code, e.g. US, GB, DE"`
+	Limit   int    `json:"limit,omitempty" jsonschema:"Max results, 1-100 (default 20). This tool does not page; raise limit for more"`
+}
+
+// GetRelationshipsArgs are the arguments for get_relationships.
+type GetRelationshipsArgs struct {
+	LEI  string `json:"lei" jsonschema:"20-character LEI code"`
+	Type string `json:"type,omitempty" jsonschema:"Relationship type: direct-parent, ultimate-parent, children, fund-manager, umbrella-fund, sub-funds (default direct-parent)"`
+}
+
+// AutocompleteArgs are the arguments for autocomplete.
+type AutocompleteArgs struct {
+	Prefix string `json:"prefix" jsonschema:"Name prefix to complete (minimum 2 characters)"`
+	Limit  int    `json:"limit,omitempty" jsonschema:"Max suggestions, 1-50 (default 10)"`
+}
+
+// GetLEIIssuerArgs are the arguments for get_lei_issuer.
+type GetLEIIssuerArgs struct {
+	IssuerID string `json:"issuer_id" jsonschema:"LEI issuer (Local Operating Unit) ID, 4-32 alphanumeric characters"`
+}
+
+// ListLEIIssuersArgs are the arguments for list_lei_issuers (none).
+type ListLEIIssuersArgs struct{}
+
+// GetReportingExceptionsArgs are the arguments for get_reporting_exceptions.
+type GetReportingExceptionsArgs struct {
+	LEI string `json:"lei" jsonschema:"20-character LEI code"`
+}
+
+// --- Result structs (for the handlers that previously returned map[string]any) ---
+
+// SimpleRecord is the trimmed entity shape shared by batch and search results.
+type SimpleRecord struct {
+	LEI       string `json:"lei"`
+	LegalName string `json:"legalName"`
+	Country   string `json:"country"`
+	City      string `json:"city"`
+	Status    string `json:"status"`
+	RegStatus string `json:"regStatus"`
+}
+
+// BatchResult is the result of batch_lei_lookup.
+type BatchResult struct {
+	Requested int            `json:"requested"`
+	Found     int            `json:"found"`
+	Results   []SimpleRecord `json:"results"`
+	NotFound  []string       `json:"notFound,omitempty"`
+}
+
+// PageInfo carries pagination metadata for search results.
+type PageInfo struct {
+	CurrentPage int `json:"currentPage"`
+	PerPage     int `json:"perPage"`
+	Total       int `json:"total"`
+	LastPage    int `json:"lastPage"`
+}
+
+// SearchEntityResult is the result of search_entity.
+type SearchEntityResult struct {
+	Count      int            `json:"count"`
+	Results    []SimpleRecord `json:"results"`
+	Pagination *PageInfo      `json:"pagination,omitempty"`
+	HasMore    *bool          `json:"hasMore,omitempty"`
+}
+
+// IDSearchResult is the result of search_by_bic and search_by_isin. The full
+// LEI records are returned (not the trimmed SimpleRecord), matching the prior
+// behaviour of these two tools.
+type IDSearchResult struct {
+	Found   bool              `json:"found"`
+	Count   int               `json:"count"`
+	Records []gleif.LEIRecord `json:"records"`
+	Message string            `json:"message,omitempty"`
+}
+
+// CountryRecord is the trimmed entity shape used by search_by_country (four
+// fields; deliberately narrower than SimpleRecord).
+type CountryRecord struct {
+	LEI       string `json:"lei"`
+	LegalName string `json:"legalName"`
+	City      string `json:"city"`
+	Status    string `json:"status"`
+}
+
+// CountrySearchResult is the result of search_by_country.
+type CountrySearchResult struct {
+	Country string          `json:"country"`
+	Count   int             `json:"count"`
+	Results []CountryRecord `json:"results"`
+}
+
+// RelationshipsResult is the result of get_relationships.
+type RelationshipsResult struct {
+	LEI           string               `json:"lei"`
+	Type          string               `json:"type"`
+	Relationships []gleif.Relationship `json:"relationships"`
+}
+
+// AutocompleteToolResult is the result of autocomplete.
+type AutocompleteToolResult struct {
+	Prefix      string                     `json:"prefix"`
+	Suggestions []gleif.AutocompleteResult `json:"suggestions"`
+}
+
+// IssuersResult is the result of list_lei_issuers.
+type IssuersResult struct {
+	Count   int               `json:"count"`
+	Issuers []gleif.LEIIssuer `json:"issuers"`
+}
+
+// ReportingExceptionsResult is the result of get_reporting_exceptions.
+type ReportingExceptionsResult struct {
+	LEI        string                     `json:"lei"`
+	Count      int                        `json:"count"`
+	Exceptions []gleif.ReportingException `json:"exceptions"`
+}

--- a/tools/definitions.go
+++ b/tools/definitions.go
@@ -1,7 +1,10 @@
 // Package tools provides MCP tool definitions and handlers for the GLEIF server.
 package tools
 
-// ToolSpec defines a tool's metadata for registration.
+// ToolSpec defines a tool's metadata for registration. Per-parameter schema is
+// no longer carried here: the input schema is derived from each handler's typed
+// Args struct (see args.go), and the output schema from its Result struct, via
+// the generic mcp.AddTool path in registry.go.
 type ToolSpec struct {
 	Name        string
 	Title       string
@@ -9,30 +12,7 @@ type ToolSpec struct {
 	Category    string
 	ReadOnly    bool
 	Idempotent  bool
-	Parameters  []ParameterSpec
 }
-
-// ParameterSpec defines a tool parameter.
-type ParameterSpec struct {
-	Name        string
-	Type        string
-	Description string
-	Required    bool
-	Enum        []string
-	MinLength   *int
-	MaxLength   *int
-	Minimum     *float64
-	Maximum     *float64
-	Default     any
-	Example     any
-	Pattern     string
-}
-
-// intPtr returns a pointer to an int value.
-func intPtr(v int) *int { return &v }
-
-// floatPtr returns a pointer to a float64 value.
-func floatPtr(v float64) *float64 { return &v }
 
 // AllTools defines all available MCP tools.
 var AllTools = []ToolSpec{
@@ -46,9 +26,6 @@ var AllTools = []ToolSpec{
 		ReadOnly:    true,
 		Idempotent:  true,
 		Description: `Get full details for a specific LEI code (legal name, address, jurisdiction, status, managing LOU, renewal dates). USE WHEN: "look up LEI", "LEI details", "who is HWUPKR0MPOU8FGXBT394?" For validating format and status only, use validate_lei. For multiple LEIs at once, use batch_lei_lookup. FAILS WHEN: LEI is not exactly 20 alphanumeric characters (fix format and retry), LEI not found in GLEIF database (entity may not have an LEI; try search_entity by name instead).`,
-		Parameters: []ParameterSpec{
-			{Name: "lei", Type: "string", Description: "20-character LEI code", Required: true, Pattern: `^[A-Z0-9]{20}$`, MinLength: intPtr(20), MaxLength: intPtr(20), Example: "HWUPKR0MPOU8FGXBT394"},
-		},
 	},
 
 	{
@@ -58,9 +35,6 @@ var AllTools = []ToolSpec{
 		ReadOnly:    true,
 		Idempotent:  true,
 		Description: `Check if an LEI code is valid and active. USE WHEN: "is this LEI valid?", "verify LEI", "check LEI format". Performs format (20 chars), check digit (ISO 17442), and database status checks. For full entity details, use lei_lookup instead. NOTE: Never returns an error for invalid LEIs; returns valid=false with a reason message instead. Safe to call on untrusted input.`,
-		Parameters: []ParameterSpec{
-			{Name: "lei", Type: "string", Description: "LEI code to validate", Required: true, Example: "HWUPKR0MPOU8FGXBT394"},
-		},
 	},
 
 	{
@@ -70,9 +44,6 @@ var AllTools = []ToolSpec{
 		ReadOnly:    true,
 		Idempotent:  true,
 		Description: `Look up multiple LEI records in one request (max 100). USE WHEN: "look up these LEIs", "batch lookup", user provides 2+ LEI codes. Faster than calling lei_lookup repeatedly. FAILS WHEN: list is empty (provide at least one LEI), more than 100 LEIs (split into multiple calls), any individual LEI has invalid format (fix that specific LEI; the error message includes its position).`,
-		Parameters: []ParameterSpec{
-			{Name: "leis", Type: "string", Description: "Comma-separated LEI codes (max 100)", Required: true, Example: "HWUPKR0MPOU8FGXBT394,7LTWFZYICNSX8D621K86"},
-		},
 	},
 
 	// =========================================================================
@@ -89,12 +60,6 @@ var AllTools = []ToolSpec{
 USE WHEN: "find company X", "search for X", "look up company X"
 
 FAILS WHEN: no results found (try autocomplete for name suggestions, or check spelling; fuzzy matching is on by default).`,
-		Parameters: []ParameterSpec{
-			{Name: "query", Type: "string", Description: "Company name to search", Required: true, MinLength: intPtr(1), Example: "Apple"},
-			{Name: "limit", Type: "integer", Description: "Max results per page (default 20)", Required: false, Minimum: floatPtr(1), Maximum: floatPtr(100), Default: 20},
-			{Name: "page", Type: "integer", Description: "Page number (default 1)", Required: false, Minimum: floatPtr(1), Default: 1},
-			{Name: "fuzzy", Type: "boolean", Description: "Use fuzzy matching (default true)", Required: false, Default: true},
-		},
 	},
 
 	{
@@ -104,9 +69,6 @@ FAILS WHEN: no results found (try autocomplete for name suggestions, or check sp
 		ReadOnly:    true,
 		Idempotent:  true,
 		Description: `Find a bank's LEI from its BIC/SWIFT code (8 or 11 characters). USE WHEN: "find LEI from BIC", "BIC to LEI", "SWIFT code lookup", user provides a BIC code. Returns matching entity with LEI, legal name, country, and registration status. FAILS WHEN: BIC is not 8 or 11 characters (fix input), no entity mapped to this BIC (not all banks have LEIs; try search_entity with the bank name instead).`,
-		Parameters: []ParameterSpec{
-			{Name: "bic", Type: "string", Description: "BIC/SWIFT code (8 or 11 chars)", Required: true, Pattern: `^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$`, Example: "DEUTDEFF"},
-		},
 	},
 
 	{
@@ -116,9 +78,6 @@ FAILS WHEN: no results found (try autocomplete for name suggestions, or check sp
 		ReadOnly:    true,
 		Idempotent:  true,
 		Description: `Find the issuer's LEI from a securities ISIN code (12 characters). USE WHEN: "who issued ISIN US0378331005?", "ISIN to LEI", user provides an ISIN. Returns issuer entity with LEI, legal name, country, and registration status. FAILS WHEN: ISIN is not 12 characters (fix input), no issuer found for this ISIN (some securities lack LEI mapping).`,
-		Parameters: []ParameterSpec{
-			{Name: "isin", Type: "string", Description: "12-character ISIN code", Required: true, Pattern: `^[A-Z]{2}[A-Z0-9]{10}$`, MinLength: intPtr(12), MaxLength: intPtr(12), Example: "US0378331005"},
-		},
 	},
 
 	{
@@ -128,10 +87,6 @@ FAILS WHEN: no results found (try autocomplete for name suggestions, or check sp
 		ReadOnly:    true,
 		Idempotent:  true,
 		Description: `List entities registered in a specific country. USE WHEN: "companies in Germany", "LEIs from US", "entities in country X". Pass ISO 2-letter code (US, GB, DE). Returns entity list with LEI, legal name, and status for each. Returns up to 'limit' results (max 100); this tool does not page, so raise 'limit' to get more rather than requesting a next page. FAILS WHEN: country code is not a 2-letter ISO 3166-1 alpha-2 code (use "US" not "USA", "GB" not "UK").`,
-		Parameters: []ParameterSpec{
-			{Name: "country", Type: "string", Description: "2-letter ISO country code", Required: true, Pattern: `^[A-Z]{2}$`, MinLength: intPtr(2), MaxLength: intPtr(2), Example: "US"},
-			{Name: "limit", Type: "integer", Description: "Max results (default 20)", Required: false, Minimum: floatPtr(1), Maximum: floatPtr(100), Default: 20},
-		},
 	},
 
 	// =========================================================================
@@ -150,10 +105,6 @@ USE WHEN: "who owns X?", "parent company", "subsidiaries", "fund manager"
 Types: direct-parent, ultimate-parent, children, fund-manager, umbrella-fund, sub-funds. Returns relationship records with related entity LEI, legal name, relationship type, and status.
 
 FAILS WHEN: LEI format invalid (must be 20 alphanumeric chars), no relationships of requested type exist (entity may have no parent; check get_reporting_exceptions for why ownership data is missing).`,
-		Parameters: []ParameterSpec{
-			{Name: "lei", Type: "string", Description: "LEI code", Required: true, Pattern: `^[A-Z0-9]{20}$`, MinLength: intPtr(20), MaxLength: intPtr(20)},
-			{Name: "type", Type: "string", Description: "Relationship type", Required: false, Enum: []string{"direct-parent", "ultimate-parent", "children", "fund-manager", "umbrella-fund", "sub-funds"}, Default: "direct-parent"},
-		},
 	},
 
 	// =========================================================================
@@ -166,10 +117,6 @@ FAILS WHEN: LEI format invalid (must be 20 alphanumeric chars), no relationships
 		ReadOnly:    true,
 		Idempotent:  true,
 		Description: `Get entity name suggestions from a prefix (min 2 characters). USE WHEN: "suggest companies starting with X", "autocomplete company name", user is typing a name and needs quick suggestions. For full search results with pagination, use search_entity instead. Returns name suggestions with LEI and legal name for each match. FAILS WHEN: prefix is shorter than 2 characters. Falls back to fuzzy search automatically if the autocomplete endpoint is unavailable.`,
-		Parameters: []ParameterSpec{
-			{Name: "prefix", Type: "string", Description: "Name prefix to complete", Required: true, MinLength: intPtr(2), Example: "Apple"},
-			{Name: "limit", Type: "integer", Description: "Max suggestions (default 10)", Required: false, Minimum: floatPtr(1), Maximum: floatPtr(50), Default: 10},
-		},
 	},
 
 	// =========================================================================
@@ -182,9 +129,6 @@ FAILS WHEN: LEI format invalid (must be 20 alphanumeric chars), no relationships
 		ReadOnly:    true,
 		Idempotent:  true,
 		Description: `Get details about a specific LEI issuer (Local Operating Unit / LOU) by ID. USE WHEN: "details on this LOU", "issuer info". Returns issuer name, country, status, website, and count of sponsored LEIs. For all issuers worldwide, use list_lei_issuers. FAILS WHEN: issuer ID not found (use list_lei_issuers to get valid IDs).`,
-		Parameters: []ParameterSpec{
-			{Name: "issuer_id", Type: "string", Description: "LEI issuer ID (4-32 alphanumeric characters)", Required: true, Pattern: `^[A-Z0-9]{4,32}$`, MinLength: intPtr(4), MaxLength: intPtr(32), Example: "EVK05KS7XY1DEII3R011"},
-		},
 	},
 
 	{
@@ -194,7 +138,6 @@ FAILS WHEN: LEI format invalid (must be 20 alphanumeric chars), no relationships
 		ReadOnly:    true,
 		Idempotent:  true,
 		Description: `List all LEI issuers (Local Operating Units / LOUs) worldwide. USE WHEN: "show all LOUs", "which organizations issue LEIs?", "LEI issuer directory". Returns all issuers with name, country, status, and sponsored LEI count. For one specific issuer, use get_lei_issuer.`,
-		Parameters:  []ParameterSpec{},
 	},
 
 	// =========================================================================
@@ -207,17 +150,14 @@ FAILS WHEN: LEI format invalid (must be 20 alphanumeric chars), no relationships
 		ReadOnly:    true,
 		Idempotent:  true,
 		Description: `Explains why parent/ownership data may be missing for an entity. USE WHEN: "why no parent info?", "reporting exceptions", "missing ownership data". Returns list of Level 2 exceptions, each with type (NON_CONSOLIDATING, NO_KNOWN_PERSON, NATURAL_PERSONS, NON_PUBLIC), category, and reference entity. Empty list when entity has no exceptions (parent data is complete). FAILS WHEN: LEI format invalid (must be 20 alphanumeric chars).`,
-		Parameters: []ParameterSpec{
-			{Name: "lei", Type: "string", Description: "LEI code", Required: true, Pattern: `^[A-Z0-9]{20}$`, MinLength: intPtr(20), MaxLength: intPtr(20)},
-		},
 	},
 }
 
 // GetToolByName returns a tool spec by name.
 func GetToolByName(name string) *ToolSpec {
-	for _, tool := range AllTools {
-		if tool.Name == name {
-			return &tool
+	for i := range AllTools {
+		if AllTools[i].Name == name {
+			return &AllTools[i]
 		}
 	}
 	return nil

--- a/tools/definitions_test.go
+++ b/tools/definitions_test.go
@@ -97,44 +97,6 @@ func TestToolDescriptionsHaveUseWhen(t *testing.T) {
 	}
 }
 
-func TestParametersHaveRequiredFields(t *testing.T) {
-	for _, tool := range AllTools {
-		for j, param := range tool.Parameters {
-			t.Run(tool.Name+"/"+param.Name, func(t *testing.T) {
-				if param.Name == "" {
-					t.Errorf("tool %q param[%d]: Name is required", tool.Name, j)
-				}
-				if param.Type == "" {
-					t.Errorf("tool %q param %q: Type is required", tool.Name, param.Name)
-				}
-				if param.Description == "" {
-					t.Errorf("tool %q param %q: Description is required", tool.Name, param.Name)
-				}
-			})
-		}
-	}
-}
-
-func TestParameterTypesValid(t *testing.T) {
-	validTypes := map[string]bool{
-		"string":  true,
-		"integer": true,
-		"boolean": true,
-		"number":  true,
-		"array":   true,
-	}
-
-	for _, tool := range AllTools {
-		for _, param := range tool.Parameters {
-			t.Run(tool.Name+"/"+param.Name, func(t *testing.T) {
-				if !validTypes[param.Type] {
-					t.Errorf("tool %q param %q has invalid type %q", tool.Name, param.Name, param.Type)
-				}
-			})
-		}
-	}
-}
-
 func TestGetToolByNameDefinitions(t *testing.T) {
 	tool := GetToolByName("lei_lookup")
 	if tool == nil {

--- a/tools/handlers.go
+++ b/tools/handlers.go
@@ -2,101 +2,74 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/olgasafonova/gleif-mcp-server/internal/gleif"
 )
 
 // Handler implementations
 //
-// Single-LEI lookups (lei_lookup, get_relationships, get_reporting_exceptions)
-// share a parse-and-call shape; the lookups that don't need extra args go
-// through handleSimpleLEILookup. Multi-arg handlers below run the parse step
-// inline because the extra arguments diverge.
+// Each handler is a typed method `func(ctx, Args) (Result, error)` registered
+// via the generic mcp.AddTool path (see registry.go). The go-sdk validates the
+// arguments against the Args-derived input schema before the handler runs, so
+// required-field presence is enforced upstream; handlers validate value-level
+// constraints (format, range) via the gleif.Parse* validators. On error the
+// handler returns a plain error, which registry.go wraps with the tool name
+// and the go-sdk surfaces as a structured tool error. On success it returns the
+// typed Result, which the go-sdk emits as structuredContent + a JSON text block.
 
-func (r *Registry) handleLEILookup(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	return r.handleSimpleLEILookup(ctx, req, "Failed to fetch LEI", func(ctx context.Context, lei gleif.LEI) (any, error) {
-		return r.client.GetLEI(ctx, lei)
-	})
+// --- Clean tools: return existing client types directly ---
+
+func (r *Registry) handleLEILookup(ctx context.Context, args LEILookupArgs) (*gleif.LEIRecord, error) {
+	lei, err := gleif.ParseLEI(args.LEI)
+	if err != nil {
+		return nil, fmt.Errorf("invalid LEI: %w", err)
+	}
+	record, err := r.client.GetLEI(ctx, lei)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch LEI: %w", err)
+	}
+	return record, nil
 }
 
-func (r *Registry) handleGetReportingExceptions(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	return r.handleSimpleLEILookup(ctx, req, "Failed to fetch reporting exceptions", func(ctx context.Context, lei gleif.LEI) (any, error) {
-		exceptions, err := r.client.GetReportingExceptions(ctx, lei)
-		if err != nil {
-			return nil, err
-		}
-		return map[string]any{
-			"lei":        string(lei),
-			"count":      len(exceptions),
-			"exceptions": exceptions,
-		}, nil
-	})
+func (r *Registry) handleValidateLEI(ctx context.Context, args ValidateLEIArgs) (*gleif.ValidationResult, error) {
+	// ValidateLEI accepts raw input on purpose: the tool's job is to report
+	// format/check-digit failures as validation results, not errors.
+	result, err := r.client.ValidateLEI(ctx, args.LEI)
+	if err != nil {
+		return nil, fmt.Errorf("validation error: %w", err)
+	}
+	return result, nil
 }
 
-func (r *Registry) handleGetLEIIssuer(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, err := parseArguments(req)
+func (r *Registry) handleGetLEIIssuer(ctx context.Context, args GetLEIIssuerArgs) (*gleif.LEIIssuer, error) {
+	issuerID, err := gleif.ParseIssuerID(args.IssuerID)
 	if err != nil {
-		return errorResult(err.Error())
-	}
-	id, ok := args["issuer_id"].(string)
-	if !ok || id == "" {
-		return errorResult("issuer_id parameter is required")
-	}
-	issuerID, err := gleif.ParseIssuerID(id)
-	if err != nil {
-		return classifyError("Invalid issuer_id", err)
+		return nil, fmt.Errorf("invalid issuer_id: %w", err)
 	}
 	issuer, err := r.client.GetLEIIssuer(ctx, issuerID)
 	if err != nil {
-		return classifyError("Failed to fetch LEI issuer", err)
+		return nil, fmt.Errorf("failed to fetch LEI issuer: %w", err)
 	}
-	return jsonResult(issuer)
+	return issuer, nil
 }
 
-func (r *Registry) handleValidateLEI(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, err := parseArguments(req)
-	if err != nil {
-		return errorResult(err.Error())
-	}
-	lei, ok := args["lei"].(string)
-	if !ok || lei == "" {
-		return errorResult("lei parameter is required")
-	}
-	// ValidateLEI accepts raw input on purpose: the tool's job is to report
-	// format/check-digit failures back as validation results.
-	result, err := r.client.ValidateLEI(ctx, lei)
-	if err != nil {
-		return classifyError("Validation error", err)
-	}
-	return jsonResult(result)
-}
+// --- Tools with structured Result types ---
 
-func (r *Registry) handleBatchLEILookup(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, err := parseArguments(req)
+func (r *Registry) handleBatchLEILookup(ctx context.Context, args BatchLEIArgs) (BatchResult, error) {
+	leis, err := parseBatchLEIs(args.LEIs)
 	if err != nil {
-		return errorResult(err.Error())
+		return BatchResult{}, fmt.Errorf("invalid LEI in batch: %w", err)
 	}
-	leisStr, ok := args["leis"].(string)
-	if !ok || leisStr == "" {
-		return errorResult("leis parameter is required")
+	if len(leis) == 0 {
+		return BatchResult{}, fmt.Errorf("no valid LEIs provided; pass one or more comma-separated 20-character LEI codes")
 	}
-
-	leis, parseErr := parseBatchLEIs(leisStr)
-	if parseErr != nil {
-		return classifyError("Invalid LEI in batch", parseErr)
-	}
-
 	records, err := r.client.GetBatchLEI(ctx, leis)
 	if err != nil {
-		return classifyError("Batch lookup failed", err)
+		return BatchResult{}, fmt.Errorf("batch lookup failed: %w", err)
 	}
-
-	return jsonResult(buildBatchResponse(leis, records))
+	return buildBatchResult(leis, records), nil
 }
 
 // parseBatchLEIs splits the comma-separated input and parses each entry.
@@ -118,9 +91,9 @@ func parseBatchLEIs(raw string) ([]gleif.LEI, error) {
 	return leis, nil
 }
 
-// buildBatchResponse shapes the batch results, including the not-found set.
-func buildBatchResponse(requested []gleif.LEI, records []gleif.LEIRecord) map[string]any {
-	results := make([]map[string]any, len(records))
+// buildBatchResult shapes the batch results, including the not-found set.
+func buildBatchResult(requested []gleif.LEI, records []gleif.LEIRecord) BatchResult {
+	results := make([]SimpleRecord, len(records))
 	foundLEIs := make(map[string]bool, len(records))
 	for i, rec := range records {
 		results[i] = simplifyRecord(rec)
@@ -134,42 +107,43 @@ func buildBatchResponse(requested []gleif.LEI, records []gleif.LEIRecord) map[st
 		}
 	}
 
-	response := map[string]any{
-		"requested": len(requested),
-		"found":     len(results),
-		"results":   results,
+	return BatchResult{
+		Requested: len(requested),
+		Found:     len(results),
+		Results:   results,
+		NotFound:  notFound,
 	}
-	if len(notFound) > 0 {
-		response["notFound"] = notFound
-	}
-	return response
 }
 
-func (r *Registry) handleSearchEntity(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, err := parseArguments(req)
-	if err != nil {
-		return errorResult(err.Error())
-	}
-	query, ok := args["query"].(string)
-	if !ok || query == "" {
-		return errorResult("query parameter is required")
+func (r *Registry) handleSearchEntity(ctx context.Context, args SearchEntityArgs) (SearchEntityResult, error) {
+	if args.Query == "" {
+		return SearchEntityResult{}, fmt.Errorf("query parameter is required")
 	}
 
-	limit := intArg(args, "limit", 20)
-	page := intArg(args, "page", 1)
-	fuzzy := boolArg(args, "fuzzy", true)
+	limit := args.Limit
+	if limit == 0 {
+		limit = 20
+	}
+	page := args.Page
+	if page == 0 {
+		page = 1
+	}
+	fuzzy := true
+	if args.Fuzzy != nil {
+		fuzzy = *args.Fuzzy
+	}
 
 	records, pagination, searchErr := r.executeSearch(ctx, searchRequest{
-		query: query,
+		query: args.Query,
 		limit: limit,
 		page:  page,
 		fuzzy: fuzzy,
 	})
 	if searchErr != nil {
-		return classifyError("Search failed", searchErr)
+		return SearchEntityResult{}, fmt.Errorf("search failed: %w", searchErr)
 	}
 
-	return jsonResult(buildSearchResponse(records, pagination))
+	return buildSearchResult(records, pagination), nil
 }
 
 // searchRequest groups parameters for executeSearch. Keeping them together
@@ -189,291 +163,181 @@ func (r *Registry) executeSearch(ctx context.Context, req searchRequest) ([]glei
 	return r.client.SearchEntities(ctx, req.query, req.limit, req.page)
 }
 
-func buildSearchResponse(records []gleif.LEIRecord, pagination *gleif.Pagination) map[string]any {
-	results := make([]map[string]any, len(records))
+func buildSearchResult(records []gleif.LEIRecord, pagination *gleif.Pagination) SearchEntityResult {
+	results := make([]SimpleRecord, len(records))
 	for i, rec := range records {
 		results[i] = simplifyRecord(rec)
 	}
-	response := map[string]any{
-		"count":   len(results),
-		"results": results,
+	result := SearchEntityResult{
+		Count:   len(results),
+		Results: results,
 	}
 	if pagination != nil {
-		response["pagination"] = map[string]any{
-			"currentPage": pagination.CurrentPage,
-			"perPage":     pagination.PerPage,
-			"total":       pagination.Total,
-			"lastPage":    pagination.LastPage,
+		result.Pagination = &PageInfo{
+			CurrentPage: pagination.CurrentPage,
+			PerPage:     pagination.PerPage,
+			Total:       pagination.Total,
+			LastPage:    pagination.LastPage,
 		}
-		response["hasMore"] = pagination.CurrentPage < pagination.LastPage
+		hasMore := pagination.CurrentPage < pagination.LastPage
+		result.HasMore = &hasMore
 	}
-	return response
+	return result
 }
 
-func (r *Registry) handleSearchByBIC(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, err := parseArguments(req)
+func (r *Registry) handleSearchByBIC(ctx context.Context, args SearchByBICArgs) (IDSearchResult, error) {
+	bic, err := gleif.ParseBIC(args.BIC)
 	if err != nil {
-		return errorResult(err.Error())
-	}
-	raw, ok := args["bic"].(string)
-	if !ok || raw == "" {
-		return errorResult("bic parameter is required")
-	}
-	bic, err := gleif.ParseBIC(raw)
-	if err != nil {
-		return classifyError("Invalid BIC", err)
+		return IDSearchResult{}, fmt.Errorf("invalid BIC: %w", err)
 	}
 	records, err := r.client.SearchByBIC(ctx, bic)
 	if err != nil {
-		return classifyError("BIC search failed", err)
+		return IDSearchResult{}, fmt.Errorf("BIC search failed: %w", err)
 	}
-	return jsonResult(buildIDSearchResponse(records, "No LEI found for this BIC code"))
+	return buildIDSearchResult(records, "No LEI found for this BIC code"), nil
 }
 
-func (r *Registry) handleSearchByISIN(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, err := parseArguments(req)
+func (r *Registry) handleSearchByISIN(ctx context.Context, args SearchByISINArgs) (IDSearchResult, error) {
+	isin, err := gleif.ParseISIN(args.ISIN)
 	if err != nil {
-		return errorResult(err.Error())
-	}
-	raw, ok := args["isin"].(string)
-	if !ok || raw == "" {
-		return errorResult("isin parameter is required")
-	}
-	isin, err := gleif.ParseISIN(raw)
-	if err != nil {
-		return classifyError("Invalid ISIN", err)
+		return IDSearchResult{}, fmt.Errorf("invalid ISIN: %w", err)
 	}
 	records, err := r.client.SearchByISIN(ctx, isin)
 	if err != nil {
-		return classifyError("ISIN search failed", err)
+		return IDSearchResult{}, fmt.Errorf("ISIN search failed: %w", err)
 	}
-	return jsonResult(buildIDSearchResponse(records, "No issuer LEI found for this ISIN"))
+	return buildIDSearchResult(records, "No issuer LEI found for this ISIN"), nil
 }
 
-// buildIDSearchResponse shapes BIC/ISIN search results uniformly. Replaces
-// the duplicate found/empty branches that CodeScene flagged across both
-// handlers.
-func buildIDSearchResponse(records []gleif.LEIRecord, emptyMessage string) map[string]any {
+// buildIDSearchResult shapes BIC/ISIN search results uniformly. The empty case
+// returns a non-nil (empty) records slice plus a message; the found case omits
+// the message.
+func buildIDSearchResult(records []gleif.LEIRecord, emptyMessage string) IDSearchResult {
 	if len(records) == 0 {
-		return map[string]any{
-			"found":   false,
-			"count":   0,
-			"records": []any{},
-			"message": emptyMessage,
+		return IDSearchResult{
+			Found:   false,
+			Count:   0,
+			Records: []gleif.LEIRecord{},
+			Message: emptyMessage,
 		}
 	}
-	return map[string]any{
-		"found":   true,
-		"count":   len(records),
-		"records": records,
+	return IDSearchResult{
+		Found:   true,
+		Count:   len(records),
+		Records: records,
 	}
 }
 
-func (r *Registry) handleSearchByCountry(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, err := parseArguments(req)
+func (r *Registry) handleSearchByCountry(ctx context.Context, args SearchByCountryArgs) (CountrySearchResult, error) {
+	country, err := gleif.ParseCountry(args.Country)
 	if err != nil {
-		return errorResult(err.Error())
-	}
-	raw, ok := args["country"].(string)
-	if !ok || raw == "" {
-		return errorResult("country parameter is required")
-	}
-	country, err := gleif.ParseCountry(raw)
-	if err != nil {
-		return classifyError("Invalid country", err)
+		return CountrySearchResult{}, fmt.Errorf("invalid country: %w", err)
 	}
 
-	limit := intArg(args, "limit", 20)
+	limit := args.Limit
+	if limit == 0 {
+		limit = 20
+	}
 	records, err := r.client.SearchByCountry(ctx, country, limit)
 	if err != nil {
-		return classifyError("Country search failed", err)
+		return CountrySearchResult{}, fmt.Errorf("country search failed: %w", err)
 	}
 
-	results := make([]map[string]any, len(records))
+	results := make([]CountryRecord, len(records))
 	for i, rec := range records {
-		results[i] = map[string]any{
-			"lei":       rec.LEI,
-			"legalName": rec.Entity.LegalName.Name,
-			"city":      rec.Entity.LegalAddress.City,
-			"status":    rec.Entity.Status,
+		results[i] = CountryRecord{
+			LEI:       rec.LEI,
+			LegalName: rec.Entity.LegalName.Name,
+			City:      rec.Entity.LegalAddress.City,
+			Status:    rec.Entity.Status,
 		}
 	}
-	return jsonResult(map[string]any{
-		"country": string(country),
-		"count":   len(results),
-		"results": results,
-	})
+	return CountrySearchResult{
+		Country: string(country),
+		Count:   len(results),
+		Results: results,
+	}, nil
 }
 
-func (r *Registry) handleGetRelationships(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, err := parseArguments(req)
+func (r *Registry) handleGetRelationships(ctx context.Context, args GetRelationshipsArgs) (RelationshipsResult, error) {
+	lei, err := gleif.ParseLEI(args.LEI)
 	if err != nil {
-		return errorResult(err.Error())
-	}
-	raw, ok := args["lei"].(string)
-	if !ok || raw == "" {
-		return errorResult("lei parameter is required")
-	}
-	lei, err := gleif.ParseLEI(raw)
-	if err != nil {
-		return classifyError("Invalid LEI", err)
+		return RelationshipsResult{}, fmt.Errorf("invalid LEI: %w", err)
 	}
 
 	relType := "direct-parent"
-	if t, ok := args["type"].(string); ok && t != "" {
-		relType = t
+	if args.Type != "" {
+		relType = args.Type
 	}
 
 	relationships, err := r.client.GetRelationships(ctx, lei, relType)
 	if err != nil {
-		return classifyError("Relationship lookup failed", err)
+		return RelationshipsResult{}, fmt.Errorf("relationship lookup failed: %w", err)
 	}
 
-	return jsonResult(map[string]any{
-		"lei":           string(lei),
-		"type":          relType,
-		"relationships": relationships,
-	})
+	return RelationshipsResult{
+		LEI:           string(lei),
+		Type:          relType,
+		Relationships: relationships,
+	}, nil
 }
 
-func (r *Registry) handleAutocomplete(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	args, err := parseArguments(req)
-	if err != nil {
-		return errorResult(err.Error())
-	}
-	prefix, ok := args["prefix"].(string)
-	if !ok || prefix == "" {
-		return errorResult("prefix parameter is required")
+func (r *Registry) handleAutocomplete(ctx context.Context, args AutocompleteArgs) (AutocompleteToolResult, error) {
+	if len(args.Prefix) < 2 {
+		return AutocompleteToolResult{}, fmt.Errorf("prefix must be at least 2 characters")
 	}
 
-	limit := intArg(args, "limit", 10)
-	suggestions, err := r.client.Autocomplete(ctx, prefix, limit)
+	limit := args.Limit
+	if limit == 0 {
+		limit = 10
+	}
+	suggestions, err := r.client.Autocomplete(ctx, args.Prefix, limit)
 	if err != nil {
-		return classifyError("Autocomplete failed", err)
+		return AutocompleteToolResult{}, fmt.Errorf("autocomplete failed: %w", err)
 	}
 
-	return jsonResult(map[string]any{
-		"prefix":      prefix,
-		"suggestions": suggestions,
-	})
+	return AutocompleteToolResult{
+		Prefix:      args.Prefix,
+		Suggestions: suggestions,
+	}, nil
 }
 
-func (r *Registry) handleListLEIIssuers(ctx context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (r *Registry) handleListLEIIssuers(ctx context.Context, _ ListLEIIssuersArgs) (IssuersResult, error) {
 	issuers, err := r.client.ListLEIIssuers(ctx)
 	if err != nil {
-		return classifyError("Failed to list LEI issuers", err)
+		return IssuersResult{}, fmt.Errorf("failed to list LEI issuers: %w", err)
 	}
-	return jsonResult(map[string]any{
-		"count":   len(issuers),
-		"issuers": issuers,
-	})
+	return IssuersResult{
+		Count:   len(issuers),
+		Issuers: issuers,
+	}, nil
 }
 
-// Helpers
-
-// handleSimpleLEILookup is the shared shape for handlers whose only argument
-// is an LEI: parse args, parse the LEI, call the client, format the response.
-// Replaces the duplicate prologue across handleLEILookup, handleGetReporting-
-// Exceptions (and previously handleGetRelationships before it grew an extra arg).
-func (r *Registry) handleSimpleLEILookup(
-	ctx context.Context,
-	req *mcp.CallToolRequest,
-	errorPrefix string,
-	call func(context.Context, gleif.LEI) (any, error),
-) (*mcp.CallToolResult, error) {
-	args, err := parseArguments(req)
+func (r *Registry) handleGetReportingExceptions(ctx context.Context, args GetReportingExceptionsArgs) (ReportingExceptionsResult, error) {
+	lei, err := gleif.ParseLEI(args.LEI)
 	if err != nil {
-		return errorResult(err.Error())
+		return ReportingExceptionsResult{}, fmt.Errorf("invalid LEI: %w", err)
 	}
-	raw, ok := args["lei"].(string)
-	if !ok || raw == "" {
-		return errorResult("lei parameter is required")
-	}
-	lei, err := gleif.ParseLEI(raw)
+	exceptions, err := r.client.GetReportingExceptions(ctx, lei)
 	if err != nil {
-		return classifyError("Invalid LEI", err)
+		return ReportingExceptionsResult{}, fmt.Errorf("failed to fetch reporting exceptions: %w", err)
 	}
-	result, err := call(ctx, lei)
-	if err != nil {
-		return classifyError(errorPrefix, err)
-	}
-	return jsonResult(result)
+	return ReportingExceptionsResult{
+		LEI:        string(lei),
+		Count:      len(exceptions),
+		Exceptions: exceptions,
+	}, nil
 }
 
 // simplifyRecord builds the trimmed-down representation used by batch and
 // search responses. Centralized to keep the field list in one place.
-func simplifyRecord(rec gleif.LEIRecord) map[string]any {
-	return map[string]any{
-		"lei":       rec.LEI,
-		"legalName": rec.Entity.LegalName.Name,
-		"country":   rec.Entity.LegalAddress.Country,
-		"city":      rec.Entity.LegalAddress.City,
-		"status":    rec.Entity.Status,
-		"regStatus": rec.Registration.Status,
+func simplifyRecord(rec gleif.LEIRecord) SimpleRecord {
+	return SimpleRecord{
+		LEI:       rec.LEI,
+		LegalName: rec.Entity.LegalName.Name,
+		Country:   rec.Entity.LegalAddress.Country,
+		City:      rec.Entity.LegalAddress.City,
+		Status:    rec.Entity.Status,
+		RegStatus: rec.Registration.Status,
 	}
-}
-
-// intArg pulls an int argument out of MCP's float64-typed JSON, falling back
-// to the supplied default if missing or wrong-typed.
-func intArg(args map[string]any, name string, def int) int {
-	if v, ok := args[name].(float64); ok {
-		return int(v)
-	}
-	return def
-}
-
-// boolArg pulls a bool argument with a fallback default.
-func boolArg(args map[string]any, name string, def bool) bool {
-	if v, ok := args[name].(bool); ok {
-		return v
-	}
-	return def
-}
-
-func parseArguments(req *mcp.CallToolRequest) (map[string]any, error) {
-	if len(req.Params.Arguments) == 0 {
-		return make(map[string]any), nil
-	}
-	var args map[string]any
-	if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
-		return nil, fmt.Errorf("failed to parse arguments: %w", err)
-	}
-	return args, nil
-}
-
-func jsonResult(data any) (*mcp.CallToolResult, error) {
-	jsonBytes, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal result: %w", err)
-	}
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: string(jsonBytes)}},
-	}, nil
-}
-
-func errorResult(message string) (*mcp.CallToolResult, error) {
-	return errorResultWithCode("error", message, false)
-}
-
-func errorResultWithCode(code, message string, retryable bool) (*mcp.CallToolResult, error) {
-	errJSON, _ := json.MarshalIndent(map[string]any{
-		"error":     true,
-		"code":      code,
-		"message":   message,
-		"retryable": retryable,
-	}, "", "  ")
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: string(errJSON)}},
-		IsError: true,
-	}, nil
-}
-
-// classifyError inspects an error and returns a structured error result with
-// the appropriate code and retryable flag from the underlying APIError, if any.
-func classifyError(prefix string, err error) (*mcp.CallToolResult, error) {
-	var apiErr *gleif.APIError
-	if errors.As(err, &apiErr) {
-		return errorResultWithCode(apiErr.Code, fmt.Sprintf("%s: %s", prefix, apiErr.Message), apiErr.Retryable)
-	}
-	return errorResultWithCode("error", fmt.Sprintf("%s: %v", prefix, err), false)
 }

--- a/tools/handlers_lookup_test.go
+++ b/tools/handlers_lookup_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/olgasafonova/gleif-mcp-server/internal/gleif"
 )
 
 // Tests for relationship, issuer, and reporting-exception handlers. Shared
-// test helpers (newTestServer, newTestRegistry, makeRequest, getResultText)
-// live in handlers_test.go in the same package.
+// test helpers (newTestServer, newTestRegistry) live in handlers_test.go in the
+// same package.
 
 // TestHandleGetRelationships tests the get_relationships handler.
 func TestHandleGetRelationships(t *testing.T) {
@@ -20,7 +19,7 @@ func TestHandleGetRelationships(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		ts.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 			resp := struct {
 				Data []any `json:"data"`
 			}{Data: []any{}}
@@ -29,40 +28,28 @@ func TestHandleGetRelationships(t *testing.T) {
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"lei": "HWUPKR0MPOU8FGXBT394"})
-
-		result, err := registry.handleGetRelationships(context.Background(), req)
+		result, err := registry.handleGetRelationships(context.Background(), GetRelationshipsArgs{LEI: "HWUPKR0MPOU8FGXBT394"})
 		if err != nil {
 			t.Fatalf("handleGetRelationships returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleGetRelationships returned error result: %s", getResultText(result))
+		if result.Type != "direct-parent" {
+			t.Errorf("expected default type 'direct-parent', got %q", result.Type)
 		}
 	})
 
 	t.Run("invalid lei format", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{"lei": "INVALID"})
-
-		result, err := registry.handleGetRelationships(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleGetRelationships returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for invalid lei format")
+		_, err := registry.handleGetRelationships(context.Background(), GetRelationshipsArgs{LEI: "INVALID"})
+		if err == nil {
+			t.Error("Expected error for invalid lei format")
 		}
 	})
 
-	t.Run("missing lei parameter", func(t *testing.T) {
+	t.Run("empty lei parameter", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleGetRelationships(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleGetRelationships returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for missing lei parameter")
+		_, err := registry.handleGetRelationships(context.Background(), GetRelationshipsArgs{LEI: ""})
+		if err == nil {
+			t.Error("Expected error for empty lei parameter")
 		}
 	})
 }
@@ -73,7 +60,7 @@ func TestHandleGetLEIIssuer(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		ts.mux.HandleFunc("/lei-issuers/", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/lei-issuers/", func(w http.ResponseWriter, _ *http.Request) {
 			resp := gleif.SingleResponse[gleif.LEIIssuer]{
 				Data: gleif.DataItem[gleif.LEIIssuer]{
 					ID:   "EVK05KS7XY1DEII3R011",
@@ -90,32 +77,20 @@ func TestHandleGetLEIIssuer(t *testing.T) {
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"issuer_id": "EVK05KS7XY1DEII3R011"})
-
-		result, err := registry.handleGetLEIIssuer(context.Background(), req)
+		issuer, err := registry.handleGetLEIIssuer(context.Background(), GetLEIIssuerArgs{IssuerID: "EVK05KS7XY1DEII3R011"})
 		if err != nil {
 			t.Fatalf("handleGetLEIIssuer returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleGetLEIIssuer returned error result: %s", getResultText(result))
-		}
-
-		text := getResultText(result)
-		if !strings.Contains(text, "WM Datenservice") {
-			t.Errorf("Expected result to contain 'WM Datenservice', got: %s", text)
+		if issuer == nil || issuer.Name != "WM Datenservice" {
+			t.Errorf("Expected issuer 'WM Datenservice', got: %+v", issuer)
 		}
 	})
 
-	t.Run("missing issuer_id parameter", func(t *testing.T) {
+	t.Run("empty issuer_id parameter", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleGetLEIIssuer(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleGetLEIIssuer returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for missing issuer_id parameter")
+		_, err := registry.handleGetLEIIssuer(context.Background(), GetLEIIssuerArgs{IssuerID: ""})
+		if err == nil {
+			t.Error("Expected error for empty issuer_id parameter")
 		}
 	})
 }
@@ -126,7 +101,7 @@ func TestHandleListLEIIssuers(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		ts.mux.HandleFunc("/lei-issuers", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/lei-issuers", func(w http.ResponseWriter, _ *http.Request) {
 			resp := gleif.APIResponse[gleif.LEIIssuer]{
 				Data: []gleif.DataItem[gleif.LEIIssuer]{
 					{
@@ -144,19 +119,12 @@ func TestHandleListLEIIssuers(t *testing.T) {
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleListLEIIssuers(context.Background(), req)
+		result, err := registry.handleListLEIIssuers(context.Background(), ListLEIIssuersArgs{})
 		if err != nil {
 			t.Fatalf("handleListLEIIssuers returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleListLEIIssuers returned error result: %s", getResultText(result))
-		}
-
-		text := getResultText(result)
-		if !strings.Contains(text, `"count": 1`) {
-			t.Errorf("Expected count=1 in result, got: %s", text)
+		if result.Count != 1 {
+			t.Errorf("Expected count=1, got %d", result.Count)
 		}
 	})
 }
@@ -167,7 +135,7 @@ func TestHandleGetReportingExceptions(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		ts.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 			resp := gleif.APIResponse[gleif.ReportingException]{
 				Data: []gleif.DataItem[gleif.ReportingException]{},
 			}
@@ -176,40 +144,28 @@ func TestHandleGetReportingExceptions(t *testing.T) {
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"lei": "HWUPKR0MPOU8FGXBT394"})
-
-		result, err := registry.handleGetReportingExceptions(context.Background(), req)
+		result, err := registry.handleGetReportingExceptions(context.Background(), GetReportingExceptionsArgs{LEI: "HWUPKR0MPOU8FGXBT394"})
 		if err != nil {
 			t.Fatalf("handleGetReportingExceptions returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleGetReportingExceptions returned error result: %s", getResultText(result))
+		if result.LEI != "HWUPKR0MPOU8FGXBT394" {
+			t.Errorf("Expected lei echoed back, got %q", result.LEI)
 		}
 	})
 
 	t.Run("invalid lei format", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{"lei": "INVALID"})
-
-		result, err := registry.handleGetReportingExceptions(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleGetReportingExceptions returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for invalid lei format")
+		_, err := registry.handleGetReportingExceptions(context.Background(), GetReportingExceptionsArgs{LEI: "INVALID"})
+		if err == nil {
+			t.Error("Expected error for invalid lei format")
 		}
 	})
 
-	t.Run("missing lei parameter", func(t *testing.T) {
+	t.Run("empty lei parameter", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleGetReportingExceptions(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleGetReportingExceptions returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for missing lei parameter")
+		_, err := registry.handleGetReportingExceptions(context.Background(), GetReportingExceptionsArgs{LEI: ""})
+		if err == nil {
+			t.Error("Expected error for empty lei parameter")
 		}
 	})
 }

--- a/tools/handlers_search_test.go
+++ b/tools/handlers_search_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/olgasafonova/gleif-mcp-server/internal/gleif"
 )
 
 // Tests for the search and autocomplete handlers. Shared test helpers
-// (newTestServer, newTestRegistry, makeRequest, getResultText,
-// mockSearchResponse) live in handlers_test.go in the same package.
+// (newTestServer, newTestRegistry, mockSearchResponse) live in handlers_test.go
+// in the same package.
 
 // TestHandleSearchEntity tests the search_entity handler.
 func TestHandleSearchEntity(t *testing.T) {
@@ -20,7 +19,7 @@ func TestHandleSearchEntity(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, _ *http.Request) {
 			resp := mockSearchResponse(
 				gleif.LEIRecord{
 					LEI:    "HWUPKR0MPOU8FGXBT394",
@@ -32,19 +31,12 @@ func TestHandleSearchEntity(t *testing.T) {
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"query": "Apple"})
-
-		result, err := registry.handleSearchEntity(context.Background(), req)
+		result, err := registry.handleSearchEntity(context.Background(), SearchEntityArgs{Query: "Apple"})
 		if err != nil {
 			t.Fatalf("handleSearchEntity returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleSearchEntity returned error result: %s", getResultText(result))
-		}
-
-		text := getResultText(result)
-		if !strings.Contains(text, "Apple Inc.") {
-			t.Errorf("Expected result to contain 'Apple Inc.', got: %s", text)
+		if result.Count != 1 || result.Results[0].LegalName != "Apple Inc." {
+			t.Errorf("Expected one Apple Inc. result, got: %+v", result)
 		}
 	})
 
@@ -52,39 +44,30 @@ func TestHandleSearchEntity(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, _ *http.Request) {
 			resp := mockSearchResponse()
 			w.Header().Set("Content-Type", "application/vnd.api+json")
 			_ = json.NewEncoder(w).Encode(resp)
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{
-			"query": "Test",
-			"limit": float64(10),
-			"page":  float64(2),
-			"fuzzy": false,
+		noFuzzy := false
+		_, err := registry.handleSearchEntity(context.Background(), SearchEntityArgs{
+			Query: "Test",
+			Limit: 10,
+			Page:  2,
+			Fuzzy: &noFuzzy,
 		})
-
-		result, err := registry.handleSearchEntity(context.Background(), req)
 		if err != nil {
 			t.Fatalf("handleSearchEntity returned error: %v", err)
-		}
-		if result.IsError {
-			t.Fatalf("handleSearchEntity returned error result: %s", getResultText(result))
 		}
 	})
 
-	t.Run("missing query parameter", func(t *testing.T) {
+	t.Run("empty query parameter", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleSearchEntity(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleSearchEntity returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for missing query parameter")
+		_, err := registry.handleSearchEntity(context.Background(), SearchEntityArgs{Query: ""})
+		if err == nil {
+			t.Error("Expected error for empty query parameter")
 		}
 	})
 }
@@ -95,7 +78,7 @@ func TestHandleSearchByBIC(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, _ *http.Request) {
 			resp := mockSearchResponse(
 				gleif.LEIRecord{
 					LEI:    "7LTWFZYICNSX8D621K86",
@@ -107,19 +90,12 @@ func TestHandleSearchByBIC(t *testing.T) {
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"bic": "DEUTDEFF"})
-
-		result, err := registry.handleSearchByBIC(context.Background(), req)
+		result, err := registry.handleSearchByBIC(context.Background(), SearchByBICArgs{BIC: "DEUTDEFF"})
 		if err != nil {
 			t.Fatalf("handleSearchByBIC returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleSearchByBIC returned error result: %s", getResultText(result))
-		}
-
-		text := getResultText(result)
-		if !strings.Contains(text, `"found": true`) {
-			t.Errorf("Expected found=true in result, got: %s", text)
+		if !result.Found {
+			t.Error("Expected found=true")
 		}
 	})
 
@@ -127,52 +103,38 @@ func TestHandleSearchByBIC(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, _ *http.Request) {
 			resp := mockSearchResponse()
 			w.Header().Set("Content-Type", "application/vnd.api+json")
 			_ = json.NewEncoder(w).Encode(resp)
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"bic": "TESTTEST"})
-
-		result, err := registry.handleSearchByBIC(context.Background(), req)
+		result, err := registry.handleSearchByBIC(context.Background(), SearchByBICArgs{BIC: "TESTTEST"})
 		if err != nil {
 			t.Fatalf("handleSearchByBIC returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleSearchByBIC returned error result: %s", getResultText(result))
+		if result.Found {
+			t.Error("Expected found=false")
 		}
-
-		text := getResultText(result)
-		if !strings.Contains(text, `"found": false`) {
-			t.Errorf("Expected found=false in result, got: %s", text)
+		if result.Records == nil {
+			t.Error("Expected non-nil (empty) records slice on no-results")
 		}
 	})
 
 	t.Run("invalid bic length", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{"bic": "TOOLONG1234567890"})
-
-		result, err := registry.handleSearchByBIC(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleSearchByBIC returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for invalid bic length")
+		_, err := registry.handleSearchByBIC(context.Background(), SearchByBICArgs{BIC: "TOOLONG1234567890"})
+		if err == nil {
+			t.Error("Expected error for invalid bic length")
 		}
 	})
 
-	t.Run("missing bic parameter", func(t *testing.T) {
+	t.Run("empty bic parameter", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleSearchByBIC(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleSearchByBIC returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for missing bic parameter")
+		_, err := registry.handleSearchByBIC(context.Background(), SearchByBICArgs{BIC: ""})
+		if err == nil {
+			t.Error("Expected error for empty bic parameter")
 		}
 	})
 }
@@ -183,7 +145,7 @@ func TestHandleSearchByISIN(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		ts.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 			resp := mockSearchResponse(
 				gleif.LEIRecord{
 					LEI:    "HWUPKR0MPOU8FGXBT394",
@@ -195,40 +157,28 @@ func TestHandleSearchByISIN(t *testing.T) {
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"isin": "US0378331005"})
-
-		result, err := registry.handleSearchByISIN(context.Background(), req)
+		result, err := registry.handleSearchByISIN(context.Background(), SearchByISINArgs{ISIN: "US0378331005"})
 		if err != nil {
 			t.Fatalf("handleSearchByISIN returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleSearchByISIN returned error result: %s", getResultText(result))
+		if !result.Found {
+			t.Error("Expected found=true")
 		}
 	})
 
 	t.Run("invalid isin length", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{"isin": "TOOLONG1234567890"})
-
-		result, err := registry.handleSearchByISIN(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleSearchByISIN returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for invalid isin length")
+		_, err := registry.handleSearchByISIN(context.Background(), SearchByISINArgs{ISIN: "TOOLONG1234567890"})
+		if err == nil {
+			t.Error("Expected error for invalid isin length")
 		}
 	})
 
-	t.Run("missing isin parameter", func(t *testing.T) {
+	t.Run("empty isin parameter", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleSearchByISIN(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleSearchByISIN returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for missing isin parameter")
+		_, err := registry.handleSearchByISIN(context.Background(), SearchByISINArgs{ISIN: ""})
+		if err == nil {
+			t.Error("Expected error for empty isin parameter")
 		}
 	})
 }
@@ -239,7 +189,7 @@ func TestHandleSearchByCountry(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, _ *http.Request) {
 			resp := mockSearchResponse(
 				gleif.LEIRecord{
 					LEI:    "HWUPKR0MPOU8FGXBT394",
@@ -251,45 +201,28 @@ func TestHandleSearchByCountry(t *testing.T) {
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"country": "US"})
-
-		result, err := registry.handleSearchByCountry(context.Background(), req)
+		result, err := registry.handleSearchByCountry(context.Background(), SearchByCountryArgs{Country: "US"})
 		if err != nil {
 			t.Fatalf("handleSearchByCountry returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleSearchByCountry returned error result: %s", getResultText(result))
-		}
-
-		text := getResultText(result)
-		if !strings.Contains(text, `"country": "US"`) {
-			t.Errorf("Expected country=US in result, got: %s", text)
+		if result.Country != "US" {
+			t.Errorf("Expected country=US, got %q", result.Country)
 		}
 	})
 
 	t.Run("invalid country code", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{"country": "USA"})
-
-		result, err := registry.handleSearchByCountry(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleSearchByCountry returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for invalid country code")
+		_, err := registry.handleSearchByCountry(context.Background(), SearchByCountryArgs{Country: "USA"})
+		if err == nil {
+			t.Error("Expected error for invalid country code")
 		}
 	})
 
-	t.Run("missing country parameter", func(t *testing.T) {
+	t.Run("empty country parameter", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleSearchByCountry(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleSearchByCountry returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for missing country parameter")
+		_, err := registry.handleSearchByCountry(context.Background(), SearchByCountryArgs{Country: ""})
+		if err == nil {
+			t.Error("Expected error for empty country parameter")
 		}
 	})
 }
@@ -300,7 +233,7 @@ func TestHandleAutocomplete(t *testing.T) {
 		ts := newTestServer()
 		defer ts.Close()
 
-		ts.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 			resp := mockSearchResponse(
 				gleif.LEIRecord{
 					LEI:    "HWUPKR0MPOU8FGXBT394",
@@ -312,32 +245,20 @@ func TestHandleAutocomplete(t *testing.T) {
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"prefix": "Apple"})
-
-		result, err := registry.handleAutocomplete(context.Background(), req)
+		result, err := registry.handleAutocomplete(context.Background(), AutocompleteArgs{Prefix: "Apple"})
 		if err != nil {
 			t.Fatalf("handleAutocomplete returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleAutocomplete returned error result: %s", getResultText(result))
-		}
-
-		text := getResultText(result)
-		if !strings.Contains(text, "suggestions") {
-			t.Errorf("Expected result to contain 'suggestions', got: %s", text)
+		if result.Prefix != "Apple" {
+			t.Errorf("Expected prefix echoed back, got %q", result.Prefix)
 		}
 	})
 
-	t.Run("missing prefix parameter", func(t *testing.T) {
+	t.Run("prefix too short", func(t *testing.T) {
 		registry := newTestRegistry("http://unused")
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleAutocomplete(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleAutocomplete returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for missing prefix parameter")
+		_, err := registry.handleAutocomplete(context.Background(), AutocompleteArgs{Prefix: "A"})
+		if err == nil {
+			t.Error("Expected error for prefix shorter than 2 characters")
 		}
 	})
 }

--- a/tools/handlers_test.go
+++ b/tools/handlers_test.go
@@ -7,11 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/olgasafonova/gleif-mcp-server/internal/gleif"
 )
 
@@ -93,95 +91,44 @@ func newTestRegistry(serverURL string) *Registry {
 	return NewRegistry(client, logger)
 }
 
-// makeRequest creates a CallToolRequest with given arguments.
-func makeRequest(args map[string]any) *mcp.CallToolRequest {
-	argBytes, _ := json.Marshal(args)
-	return &mcp.CallToolRequest{
-		Params: &mcp.CallToolParamsRaw{
-			Arguments: argBytes,
-		},
-	}
-}
-
-// getResultText extracts text from a CallToolResult.
-func getResultText(result *mcp.CallToolResult) string {
-	if len(result.Content) == 0 {
-		return ""
-	}
-	if textContent, ok := result.Content[0].(*mcp.TextContent); ok {
-		return textContent.Text
-	}
-	return ""
-}
-
 // TestHandleLEILookup tests the lei_lookup handler.
 func TestHandleLEILookup(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()
 
 	t.Run("successful lookup", func(t *testing.T) {
-		ts.mux.HandleFunc("/lei-records/HWUPKR0MPOU8FGXBT394", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/lei-records/HWUPKR0MPOU8FGXBT394", func(w http.ResponseWriter, _ *http.Request) {
 			resp := mockLEIResponse("HWUPKR0MPOU8FGXBT394", "Apple Inc.", "US", "Cupertino")
 			w.Header().Set("Content-Type", "application/vnd.api+json")
 			_ = json.NewEncoder(w).Encode(resp)
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"lei": "HWUPKR0MPOU8FGXBT394"})
-
-		result, err := registry.handleLEILookup(context.Background(), req)
+		record, err := registry.handleLEILookup(context.Background(), LEILookupArgs{LEI: "HWUPKR0MPOU8FGXBT394"})
 		if err != nil {
 			t.Fatalf("handleLEILookup returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleLEILookup returned error result: %s", getResultText(result))
+		if record == nil {
+			t.Fatal("handleLEILookup returned nil record")
 		}
-
-		text := getResultText(result)
-		if !strings.Contains(text, "Apple Inc.") {
-			t.Errorf("Expected result to contain 'Apple Inc.', got: %s", text)
-		}
-	})
-
-	t.Run("missing lei parameter", func(t *testing.T) {
-		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleLEILookup(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleLEILookup returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for missing lei parameter")
-		}
-		if !strings.Contains(getResultText(result), "lei parameter is required") {
-			t.Errorf("Expected error message containing 'lei parameter is required', got: %s", getResultText(result))
+		if record.Entity.LegalName.Name != "Apple Inc." {
+			t.Errorf("Expected legal name 'Apple Inc.', got: %s", record.Entity.LegalName.Name)
 		}
 	})
 
 	t.Run("empty lei parameter", func(t *testing.T) {
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"lei": ""})
-
-		result, err := registry.handleLEILookup(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleLEILookup returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for empty lei parameter")
+		_, err := registry.handleLEILookup(context.Background(), LEILookupArgs{LEI: ""})
+		if err == nil {
+			t.Error("Expected error for empty lei parameter")
 		}
 	})
 
 	t.Run("invalid lei format", func(t *testing.T) {
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"lei": "INVALID"})
-
-		result, err := registry.handleLEILookup(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleLEILookup returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for invalid lei format")
+		_, err := registry.handleLEILookup(context.Background(), LEILookupArgs{LEI: "INVALID"})
+		if err == nil {
+			t.Error("Expected error for invalid lei format")
 		}
 	})
 }
@@ -192,57 +139,30 @@ func TestHandleValidateLEI(t *testing.T) {
 	defer ts.Close()
 
 	t.Run("valid lei with record", func(t *testing.T) {
-		ts.mux.HandleFunc("/lei-records/HWUPKR0MPOU8FGXBT394", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/lei-records/HWUPKR0MPOU8FGXBT394", func(w http.ResponseWriter, _ *http.Request) {
 			resp := mockLEIResponse("HWUPKR0MPOU8FGXBT394", "Apple Inc.", "US", "Cupertino")
 			w.Header().Set("Content-Type", "application/vnd.api+json")
 			_ = json.NewEncoder(w).Encode(resp)
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"lei": "HWUPKR0MPOU8FGXBT394"})
-
-		result, err := registry.handleValidateLEI(context.Background(), req)
+		result, err := registry.handleValidateLEI(context.Background(), ValidateLEIArgs{LEI: "HWUPKR0MPOU8FGXBT394"})
 		if err != nil {
 			t.Fatalf("handleValidateLEI returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleValidateLEI returned error result: %s", getResultText(result))
-		}
-
-		text := getResultText(result)
-		if !strings.Contains(text, `"valid": true`) {
-			t.Errorf("Expected valid=true in result, got: %s", text)
+		if !result.Valid {
+			t.Errorf("Expected valid=true, got valid=false (message: %s)", result.Message)
 		}
 	})
 
 	t.Run("invalid format without API call", func(t *testing.T) {
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"lei": "TOOSHORT"})
-
-		result, err := registry.handleValidateLEI(context.Background(), req)
+		result, err := registry.handleValidateLEI(context.Background(), ValidateLEIArgs{LEI: "TOOSHORT"})
 		if err != nil {
 			t.Fatalf("handleValidateLEI returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleValidateLEI returned error result: %s", getResultText(result))
-		}
-
-		text := getResultText(result)
-		if !strings.Contains(text, `"valid": false`) {
-			t.Errorf("Expected valid=false in result, got: %s", text)
-		}
-	})
-
-	t.Run("missing lei parameter", func(t *testing.T) {
-		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleValidateLEI(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleValidateLEI returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for missing lei parameter")
+		if result.Valid {
+			t.Error("Expected valid=false for malformed LEI")
 		}
 	})
 }
@@ -253,7 +173,7 @@ func TestHandleBatchLEILookup(t *testing.T) {
 	defer ts.Close()
 
 	t.Run("successful batch lookup", func(t *testing.T) {
-		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, r *http.Request) {
+		ts.mux.HandleFunc("/lei-records", func(w http.ResponseWriter, _ *http.Request) {
 			resp := mockSearchResponse(
 				gleif.LEIRecord{
 					LEI:    "HWUPKR0MPOU8FGXBT394",
@@ -269,167 +189,42 @@ func TestHandleBatchLEILookup(t *testing.T) {
 		})
 
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"leis": "HWUPKR0MPOU8FGXBT394,7LTWFZYICNSX8D621K86"})
-
-		result, err := registry.handleBatchLEILookup(context.Background(), req)
+		result, err := registry.handleBatchLEILookup(context.Background(), BatchLEIArgs{LEIs: "HWUPKR0MPOU8FGXBT394,7LTWFZYICNSX8D621K86"})
 		if err != nil {
 			t.Fatalf("handleBatchLEILookup returned error: %v", err)
 		}
-		if result.IsError {
-			t.Fatalf("handleBatchLEILookup returned error result: %s", getResultText(result))
-		}
-
-		text := getResultText(result)
-		if !strings.Contains(text, `"requested": 2`) {
-			t.Errorf("Expected requested=2 in result, got: %s", text)
+		if result.Requested != 2 {
+			t.Errorf("Expected requested=2, got %d", result.Requested)
 		}
 	})
 
-	t.Run("missing leis parameter", func(t *testing.T) {
+	t.Run("empty leis parameter", func(t *testing.T) {
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{})
-
-		result, err := registry.handleBatchLEILookup(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleBatchLEILookup returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for missing leis parameter")
+		_, err := registry.handleBatchLEILookup(context.Background(), BatchLEIArgs{LEIs: ""})
+		if err == nil {
+			t.Error("Expected error for empty leis parameter")
 		}
 	})
 
 	t.Run("invalid lei in batch", func(t *testing.T) {
 		registry := newTestRegistry(ts.URL())
-		req := makeRequest(map[string]any{"leis": "HWUPKR0MPOU8FGXBT394,INVALID"})
-
-		result, err := registry.handleBatchLEILookup(context.Background(), req)
-		if err != nil {
-			t.Fatalf("handleBatchLEILookup returned error: %v", err)
-		}
-		if !result.IsError {
-			t.Error("Expected error result for invalid lei in batch")
+		_, err := registry.handleBatchLEILookup(context.Background(), BatchLEIArgs{LEIs: "HWUPKR0MPOU8FGXBT394,INVALID"})
+		if err == nil {
+			t.Error("Expected error for invalid lei in batch")
 		}
 	})
 }
 
-// TestParseArgumentsEmptyRequest tests parseArguments with empty request.
-func TestParseArgumentsEmptyRequest(t *testing.T) {
-	req := &mcp.CallToolRequest{
-		Params: &mcp.CallToolParamsRaw{
-			Arguments: nil,
-		},
-	}
-
-	args, err := parseArguments(req)
-	if err != nil {
-		t.Fatalf("parseArguments returned error: %v", err)
-	}
-	if len(args) != 0 {
-		t.Errorf("Expected empty args map, got %d entries", len(args))
-	}
-}
-
-// TestParseArgumentsInvalidJSON tests parseArguments with invalid JSON.
-func TestParseArgumentsInvalidJSON(t *testing.T) {
-	req := &mcp.CallToolRequest{
-		Params: &mcp.CallToolParamsRaw{
-			Arguments: json.RawMessage(`{invalid json}`),
-		},
-	}
-
-	_, err := parseArguments(req)
-	if err == nil {
-		t.Error("Expected error for invalid JSON")
-	}
-}
-
-// TestErrorResult tests the errorResult helper.
-func TestErrorResult(t *testing.T) {
-	result, err := errorResult("test error message")
-	if err != nil {
-		t.Fatalf("errorResult returned error: %v", err)
-	}
-	if !result.IsError {
-		t.Error("Expected IsError=true")
-	}
-	text := getResultText(result)
-	// Error results are now structured JSON
-	var errResp map[string]any
-	if jsonErr := json.Unmarshal([]byte(text), &errResp); jsonErr != nil {
-		t.Fatalf("errorResult did not return valid JSON: %v", jsonErr)
-	}
-	if errResp["error"] != true {
-		t.Error("Expected error=true in JSON response")
-	}
-	if errResp["message"] != "test error message" {
-		t.Errorf("Expected message 'test error message', got: %v", errResp["message"])
-	}
-	if errResp["retryable"] != false {
-		t.Error("Expected retryable=false in JSON response")
-	}
-}
-
-// TestJSONResult tests the jsonResult helper.
-func TestJSONResult(t *testing.T) {
-	data := map[string]any{"key": "value"}
-	result, err := jsonResult(data)
-	if err != nil {
-		t.Fatalf("jsonResult returned error: %v", err)
-	}
-	if result.IsError {
-		t.Error("Expected IsError=false")
-	}
-	text := getResultText(result)
-	if !strings.Contains(text, `"key": "value"`) {
-		t.Errorf("Expected JSON with key=value, got: %s", text)
-	}
-}
-
-// TestGetToolByName tests tool spec lookup.
-func TestGetToolByName(t *testing.T) {
-	tests := []struct {
-		name     string
-		toolName string
-		wantNil  bool
-	}{
-		{"existing tool", "lei_lookup", false},
-		{"another tool", "search_entity", false},
-		{"nonexistent", "nonexistent_tool", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			spec := GetToolByName(tt.toolName)
-			if (spec == nil) != tt.wantNil {
-				t.Errorf("GetToolByName(%q) nil=%v, wantNil=%v", tt.toolName, spec == nil, tt.wantNil)
-			}
-		})
-	}
-}
-
-// TestToolSpecsComplete verifies all tools have required fields.
-func TestToolSpecsComplete(t *testing.T) {
+// TestEveryToolHasHandler asserts the dispatch map covers every AllTools entry,
+// so a tool can never be advertised without a registered handler.
+func TestEveryToolHasHandler(t *testing.T) {
+	registry := newTestRegistry("http://example.invalid")
 	for _, spec := range AllTools {
-		t.Run(spec.Name, func(t *testing.T) {
-			if spec.Name == "" {
-				t.Error("Tool has empty name")
-			}
-			if spec.Description == "" {
-				t.Errorf("Tool %s has empty description", spec.Name)
-			}
-			if spec.Category == "" {
-				t.Errorf("Tool %s has empty category", spec.Name)
-			}
-
-			// Check required parameters have descriptions
-			for _, param := range spec.Parameters {
-				if param.Name == "" {
-					t.Errorf("Tool %s has parameter with empty name", spec.Name)
-				}
-				if param.Type == "" {
-					t.Errorf("Tool %s parameter %s has empty type", spec.Name, param.Name)
-				}
-			}
-		})
+		if _, ok := registry.handlers[spec.Name]; !ok {
+			t.Errorf("tool %q has no handler in the dispatch map", spec.Name)
+		}
+	}
+	if len(registry.handlers) != len(AllTools) {
+		t.Errorf("handler count %d != AllTools count %d (orphaned handler?)", len(registry.handlers), len(AllTools))
 	}
 }

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -14,8 +16,12 @@ import (
 type Registry struct {
 	client   *gleif.Client
 	logger   *slog.Logger
-	handlers map[string]mcp.ToolHandler
+	handlers map[string]registrationFunc
 }
+
+// registrationFunc registers one tool with the server. It erases the per-tool
+// Args/Result type parameters so all tools can live in a single dispatch map.
+type registrationFunc func(server *mcp.Server, spec ToolSpec)
 
 // NewRegistry creates a new tool registry.
 func NewRegistry(client *gleif.Client, logger *slog.Logger) *Registry {
@@ -27,147 +33,112 @@ func NewRegistry(client *gleif.Client, logger *slog.Logger) *Registry {
 	return r
 }
 
-// buildHandlerMap returns the name → handler dispatch table. A map collapses
-// the prior 12-arm switch (cc=13) into a constant-complexity lookup.
-func (r *Registry) buildHandlerMap() map[string]mcp.ToolHandler {
-	return map[string]mcp.ToolHandler{
-		"lei_lookup":               r.handleLEILookup,
-		"validate_lei":             r.handleValidateLEI,
-		"batch_lei_lookup":         r.handleBatchLEILookup,
-		"search_entity":            r.handleSearchEntity,
-		"search_by_bic":            r.handleSearchByBIC,
-		"search_by_isin":           r.handleSearchByISIN,
-		"search_by_country":        r.handleSearchByCountry,
-		"get_relationships":        r.handleGetRelationships,
-		"autocomplete":             r.handleAutocomplete,
-		"get_lei_issuer":           r.handleGetLEIIssuer,
-		"list_lei_issuers":         r.handleListLEIIssuers,
-		"get_reporting_exceptions": r.handleGetReportingExceptions,
+// buildHandlerMap returns the name → registration dispatch table. makeHandler
+// captures each typed handler method and adapts it to the uniform
+// registrationFunc signature.
+func (r *Registry) buildHandlerMap() map[string]registrationFunc {
+	return map[string]registrationFunc{
+		"lei_lookup":               makeHandler(r, r.handleLEILookup),
+		"validate_lei":             makeHandler(r, r.handleValidateLEI),
+		"batch_lei_lookup":         makeHandler(r, r.handleBatchLEILookup),
+		"search_entity":            makeHandler(r, r.handleSearchEntity),
+		"search_by_bic":            makeHandler(r, r.handleSearchByBIC),
+		"search_by_isin":           makeHandler(r, r.handleSearchByISIN),
+		"search_by_country":        makeHandler(r, r.handleSearchByCountry),
+		"get_relationships":        makeHandler(r, r.handleGetRelationships),
+		"autocomplete":             makeHandler(r, r.handleAutocomplete),
+		"get_lei_issuer":           makeHandler(r, r.handleGetLEIIssuer),
+		"list_lei_issuers":         makeHandler(r, r.handleListLEIIssuers),
+		"get_reporting_exceptions": makeHandler(r, r.handleGetReportingExceptions),
 	}
 }
 
 // RegisterAll registers all tools with the MCP server.
 func (r *Registry) RegisterAll(server *mcp.Server) {
 	for _, spec := range AllTools {
-		r.registerTool(server, spec)
+		register, ok := r.handlers[spec.Name]
+		if !ok {
+			r.logger.Warn("No handler registered for tool, skipping", "tool", spec.Name)
+			continue
+		}
+		register(server, spec)
 	}
 	r.logger.Debug("Registered MCP tools", "count", len(AllTools))
 }
 
-func (r *Registry) registerTool(server *mcp.Server, spec ToolSpec) {
-	inputSchema := buildInputSchema(spec.Parameters)
-	handler := r.lookupHandler(spec.Name)
+// makeHandler adapts a typed handler method into a uniform registrationFunc.
+// This is the only place per-tool type parameters are needed.
+func makeHandler[Args, Result any](r *Registry, method func(context.Context, Args) (Result, error)) registrationFunc {
+	return func(server *mcp.Server, spec ToolSpec) {
+		registerTyped(r, server, spec, method)
+	}
+}
 
-	server.AddTool(&mcp.Tool{
+// registerTyped wires one typed handler into the server via the generic
+// mcp.AddTool. The Args struct drives the input schema; the Result struct drives
+// the output schema and structuredContent (both auto-derived by the go-sdk). The
+// named returns plus the deferred recoverPanic are load-bearing for HG-1: a
+// panic must surface as a structured error, not as a silent (nil, zero, nil).
+func registerTyped[Args, Result any](
+	r *Registry,
+	server *mcp.Server,
+	spec ToolSpec,
+	method func(context.Context, Args) (Result, error),
+) {
+	tool := buildTool(spec)
+	mcp.AddTool(server, tool, func(ctx context.Context, _ *mcp.CallToolRequest, args Args) (res *mcp.CallToolResult, out Result, err error) {
+		defer r.recoverPanic(spec.Name, &err)
+
+		result, methodErr := method(ctx, args)
+		if methodErr != nil {
+			var zero Result
+			return nil, zero, fmt.Errorf("%s: %w", spec.Name, methodErr)
+		}
+		return nil, result, nil
+	})
+}
+
+// buildTool constructs the tool metadata. InputSchema is left nil so the go-sdk
+// infers it from the handler's Args type.
+func buildTool(spec ToolSpec) *mcp.Tool {
+	return &mcp.Tool{
 		Name:        spec.Name,
 		Description: spec.Description,
-		InputSchema: inputSchema,
 		Annotations: &mcp.ToolAnnotations{
 			Title:          spec.Title,
 			ReadOnlyHint:   spec.ReadOnly,
 			IdempotentHint: spec.Idempotent,
 		},
-	}, r.wrapHandler(spec.Name, handler))
-}
-
-// buildInputSchema converts ParameterSpec slice to MCP input schema map.
-// Extracted from registerTool to drop its cyclomatic complexity below the
-// Go threshold; the per-property field copying is contained here.
-func buildInputSchema(params []ParameterSpec) map[string]any {
-	properties := make(map[string]any, len(params))
-	required := []string{}
-
-	for _, p := range params {
-		properties[p.Name] = buildPropertySchema(p)
-		if p.Required {
-			required = append(required, p.Name)
-		}
-	}
-
-	schema := map[string]any{
-		"type":       "object",
-		"properties": properties,
-	}
-	if len(required) > 0 {
-		schema["required"] = required
-	}
-	return schema
-}
-
-// buildPropertySchema renders one ParameterSpec as a JSON-Schema property map.
-func buildPropertySchema(p ParameterSpec) map[string]any {
-	prop := map[string]any{
-		"type":        p.Type,
-		"description": p.Description,
-	}
-	addLengthBounds(prop, p)
-	addNumericBounds(prop, p)
-	addEnumAndExample(prop, p)
-	addDefaultAndPattern(prop, p)
-	return prop
-}
-
-// addLengthBounds copies MinLength / MaxLength into the property map when set.
-func addLengthBounds(prop map[string]any, p ParameterSpec) {
-	if p.MinLength != nil {
-		prop["minLength"] = *p.MinLength
-	}
-	if p.MaxLength != nil {
-		prop["maxLength"] = *p.MaxLength
 	}
 }
 
-// addNumericBounds copies Minimum / Maximum into the property map when set.
-func addNumericBounds(prop map[string]any, p ParameterSpec) {
-	if p.Minimum != nil {
-		prop["minimum"] = *p.Minimum
+// recoverPanic converts a recovered panic into a structured tool error with a
+// correlation ID (HG-1). The panic value and stack are logged server-side only;
+// the MCP caller sees just the tool name and correlation ID, never the panic
+// value. Writing through errPtr is what turns the panic into an error rather
+// than a silent empty success.
+func (r *Registry) recoverPanic(toolName string, errPtr *error) {
+	rec := recover()
+	if rec == nil {
+		return
 	}
-	if p.Maximum != nil {
-		prop["maximum"] = *p.Maximum
-	}
-}
-
-// addEnumAndExample copies enum and example values into the property map.
-func addEnumAndExample(prop map[string]any, p ParameterSpec) {
-	if len(p.Enum) > 0 {
-		prop["enum"] = p.Enum
-	}
-	if p.Example != nil {
-		prop["examples"] = []any{p.Example}
-	}
-}
-
-// addDefaultAndPattern copies Default and Pattern into the property map.
-func addDefaultAndPattern(prop map[string]any, p ParameterSpec) {
-	if p.Default != nil {
-		prop["default"] = p.Default
-	}
-	if p.Pattern != "" {
-		prop["pattern"] = p.Pattern
+	corrID := newCorrelationID()
+	r.logger.Error("Panic recovered in tool handler",
+		"tool", toolName,
+		"correlation_id", corrID,
+		"panic", rec,
+		"stack", string(debug.Stack()))
+	if errPtr != nil {
+		*errPtr = fmt.Errorf("%s: internal error (correlation_id=%s)", toolName, corrID)
 	}
 }
 
-func (r *Registry) lookupHandler(name string) mcp.ToolHandler {
-	if h, ok := r.handlers[name]; ok {
-		return h
+// newCorrelationID returns a short random hex ID for correlating a sanitized
+// caller-facing error with the full server-side log entry.
+func newCorrelationID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "unknown"
 	}
-	return func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return errorResult(fmt.Sprintf("Unknown tool: %s", name))
-	}
-}
-
-// wrapHandler adds panic recovery around a tool handler.
-func (r *Registry) wrapHandler(toolName string, handler mcp.ToolHandler) mcp.ToolHandler {
-	return func(ctx context.Context, req *mcp.CallToolRequest) (result *mcp.CallToolResult, err error) {
-		defer func() {
-			if rec := recover(); rec != nil {
-				r.logger.Error("Panic recovered in tool handler",
-					"tool", toolName,
-					"panic", rec,
-					"stack", string(debug.Stack()))
-				result, err = errorResult(fmt.Sprintf("Internal error in %s", toolName))
-			}
-		}()
-		return handler(ctx, req)
-	}
+	return hex.EncodeToString(b)
 }

--- a/tools/registry_test.go
+++ b/tools/registry_test.go
@@ -2,64 +2,171 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// Tests for the registration/dispatch machinery in registry.go
-// (Registry, NewRegistry, lookupHandler, wrapHandler). Shared test helpers
-// (newTestRegistry, makeRequest, getResultText) live in handlers_test.go in
-// the same package.
+// Tests for the registration/dispatch machinery in registry.go, exercised
+// end-to-end over an in-memory transport. Shared test helpers (newTestServer,
+// newTestRegistry, mockLEIResponse) live in handlers_test.go in the same package.
 
-// TestGetHandler tests the getHandler dispatcher.
-func TestGetHandler(t *testing.T) {
-	registry := newTestRegistry("http://unused")
+// connectInMemory registers the registry on a fresh server and returns a
+// connected in-memory client session. RegisterAll panics if any tool's Args or
+// Result type fails to resolve to a JSON schema, so reaching the return is
+// itself an assertion that all 12 tools' schemas are valid.
+func connectInMemory(t *testing.T, registry *Registry) *mcp.ClientSession {
+	t.Helper()
+	server := mcp.NewServer(&mcp.Implementation{Name: "gleif-test", Version: "0.0.0"}, nil)
+	registry.RegisterAll(server)
 
-	tests := []struct {
-		name     string
-		toolName string
-		wantNil  bool
-	}{
-		{"lei_lookup", "lei_lookup", false},
-		{"validate_lei", "validate_lei", false},
-		{"batch_lei_lookup", "batch_lei_lookup", false},
-		{"search_entity", "search_entity", false},
-		{"search_by_bic", "search_by_bic", false},
-		{"search_by_isin", "search_by_isin", false},
-		{"search_by_country", "search_by_country", false},
-		{"get_relationships", "get_relationships", false},
-		{"autocomplete", "autocomplete", false},
-		{"get_lei_issuer", "get_lei_issuer", false},
-		{"list_lei_issuers", "list_lei_issuers", false},
-		{"get_reporting_exceptions", "get_reporting_exceptions", false},
-		{"unknown_tool", "nonexistent_tool", false}, // Returns error handler
+	serverT, clientT := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	ss, err := server.Connect(ctx, serverT, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
 	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
+	cs, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cs.Close()
+		_ = ss.Close()
+	})
+	return cs
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			handler := registry.lookupHandler(tt.toolName)
-			if handler == nil && !tt.wantNil {
-				t.Errorf("lookupHandler(%q) returned nil", tt.toolName)
-			}
-		})
+// contentText extracts the first text content block from a tool result.
+func contentText(res *mcp.CallToolResult) string {
+	if len(res.Content) == 0 {
+		return ""
+	}
+	if tc, ok := res.Content[0].(*mcp.TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}
+
+// TestRegisterAllSchemas confirms every tool registers with a resolvable input
+// AND output schema. The output schema is the point of the migration: it is what
+// gives Code Mode callers typed, structured tool results.
+func TestRegisterAllSchemas(t *testing.T) {
+	registry := newTestRegistry("http://example.invalid")
+	cs := connectInMemory(t, registry)
+
+	res, err := cs.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(res.Tools) != len(AllTools) {
+		t.Fatalf("expected %d tools, got %d", len(AllTools), len(res.Tools))
+	}
+	for _, tool := range res.Tools {
+		if tool.InputSchema == nil {
+			t.Errorf("tool %q has nil InputSchema", tool.Name)
+		}
+		if tool.OutputSchema == nil {
+			t.Errorf("tool %q has nil OutputSchema (structuredContent will not be typed)", tool.Name)
+		}
 	}
 }
 
-// TestUnknownToolHandler tests that unknown tools return an error.
-func TestUnknownToolHandler(t *testing.T) {
-	registry := newTestRegistry("http://unused")
-	handler := registry.lookupHandler("nonexistent_tool")
-	req := makeRequest(map[string]any{})
+// TestCallToolStructuredContent drives lei_lookup end-to-end and asserts the
+// result carries structuredContent (not just a text blob).
+func TestCallToolStructuredContent(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+	ts.mux.HandleFunc("/lei-records/HWUPKR0MPOU8FGXBT394", func(w http.ResponseWriter, _ *http.Request) {
+		resp := mockLEIResponse("HWUPKR0MPOU8FGXBT394", "Apple Inc.", "US", "Cupertino")
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
 
-	result, err := handler(context.Background(), req)
+	registry := newTestRegistry(ts.URL())
+	cs := connectInMemory(t, registry)
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "lei_lookup",
+		Arguments: map[string]any{"lei": "HWUPKR0MPOU8FGXBT394"},
+	})
 	if err != nil {
-		t.Fatalf("Unknown tool handler returned error: %v", err)
+		t.Fatalf("CallTool: %v", err)
 	}
-	if !result.IsError {
-		t.Error("Expected error result for unknown tool")
+	if res.IsError {
+		t.Fatalf("tool returned error: %s", contentText(res))
 	}
-	text := getResultText(result)
-	if !strings.Contains(text, "Unknown tool") {
-		t.Errorf("Expected 'Unknown tool' in error message, got: %s", text)
+	if res.StructuredContent == nil {
+		t.Fatal("expected non-nil StructuredContent")
+	}
+	raw, _ := json.Marshal(res.StructuredContent)
+	if !strings.Contains(string(raw), "Apple Inc.") {
+		t.Errorf("structuredContent missing 'Apple Inc.': %s", raw)
+	}
+}
+
+// TestCallToolMissingRequired confirms the input schema rejects a missing
+// required field before the handler runs (required-ness is now schema-enforced).
+func TestCallToolMissingRequired(t *testing.T) {
+	registry := newTestRegistry("http://example.invalid")
+	cs := connectInMemory(t, registry)
+
+	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "lei_lookup",
+		Arguments: map[string]any{}, // missing required "lei"
+	})
+	if err != nil {
+		t.Fatalf("CallTool transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError for missing required 'lei' (schema validation)")
+	}
+}
+
+// TestPanicRecovery is the HG-1 coverage assertion: a panicking handler must
+// surface as a structured tool error with a correlation ID, and the panic value
+// must never reach the caller.
+func TestPanicRecovery(t *testing.T) {
+	registry := newTestRegistry("http://example.invalid")
+	server := mcp.NewServer(&mcp.Implementation{Name: "gleif-test", Version: "0.0.0"}, nil)
+	spec := ToolSpec{Name: "boom", Title: "Boom", Description: "panics for testing", ReadOnly: true}
+	registerTyped(registry, server, spec, func(_ context.Context, _ LEILookupArgs) (IssuersResult, error) {
+		panic("kaboom-secret-internal-detail")
+	})
+
+	serverT, clientT := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	ss, err := server.Connect(ctx, serverT, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	defer func() { _ = ss.Close() }()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
+	cs, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "boom",
+		Arguments: map[string]any{"lei": "HWUPKR0MPOU8FGXBT394"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError after handler panic")
+	}
+	text := contentText(res)
+	if strings.Contains(text, "kaboom-secret-internal-detail") {
+		t.Errorf("panic value leaked to caller: %s", text)
+	}
+	if !strings.Contains(text, "correlation_id=") {
+		t.Errorf("expected correlation_id in caller-facing error, got: %s", text)
 	}
 }


### PR DESCRIPTION
## Summary

Migrates all 12 read-only GLEIF tools from manual `mcp.Tool{InputSchema: map}` registration to the go-sdk generic `mcp.AddTool[Args, Result]` path. Each tool now has a typed `Args` struct (drives the input schema) and a concrete `Result` struct (auto-derives `OutputSchema` + `structuredContent`), so Code Mode callers get typed, structured tool output. **All 12 tools now expose an `outputSchema`; previously none did.**

Bead: `claude-code-config-6wsu`.

## What changed

- **`tools/args.go`** (new) — typed `Args` structs for all 12 tools + concrete `Result` structs for the 9 handlers that previously returned `map[string]any` (which reflects to an empty schema, defeating the goal). The 3 already-typed tools (`lei_lookup`, `validate_lei`, `get_lei_issuer`) return their existing client types directly.
- **`tools/registry.go`** — generic `register`/`makeHandler` + `recoverPanic`-via-`*errPtr` (HG-1). A panic now surfaces as a structured tool error with a correlation ID; the panic value is logged server-side only, never returned to the caller. Dropped the hand-rolled `buildInputSchema`/`ParameterSpec` machinery (schema is now reflected from `Args`) and the old `wrapHandler`.
- **`tools/handlers.go`** — typed handlers `func(ctx, Args) (Result, error)`. Removed `jsonResult`/`errorResult`/`classifyError`/`parseArguments`/`intArg`/`boolArg` (dead under the generic path). Required-field presence is now enforced by the input schema before the handler runs; handlers keep value-level validation via `gleif.Parse*`.
- **`tools/definitions.go`** — `ToolSpec` slimmed to metadata only (`Parameters`/`ParameterSpec` removed). Tool descriptions are unchanged.

## Tag-convention finding

Verified empirically against `google/jsonschema-go` v0.4.3 (the library the go-sdk uses): a field is REQUIRED unless it carries `,omitempty`, and the `jsonschema:"..."` tag value becomes the property **description**. The `jsonschema:"required"` + `jsonschema_description:"..."` convention used by nordic-registry is a latent bug there — it sets the description to the literal word "required" and silently ignores the real text. This PR uses the convention the library actually honours, so parameter descriptions render correctly.

## Tests

Handler-level tests rewritten to the typed signatures; added an end-to-end suite over the in-memory transport (`registry_test.go`) asserting:
- all 12 schemas resolve and every tool has an `outputSchema`
- `structuredContent` is emitted on a real call
- the input schema rejects a missing required field
- HG-1 panic recovery surfaces a correlation ID without leaking the panic value

## Verification

- `make check` (golangci-lint + `go test -race`) green
- Live stdio smoke: 12 tools, 12 outputSchemas, correct required-field + description rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)