### PR TITLE
feat(hg2): cap list_lei_issuers + project BIC/ISIN search results

### DIFF
--- a/tools/args.go
+++ b/tools/args.go
@@ -75,8 +75,10 @@ type GetLEIIssuerArgs struct {
 	IssuerID string `json:"issuer_id" jsonschema:"LEI issuer (Local Operating Unit) ID, 4-32 alphanumeric characters"`
 }
 
-// ListLEIIssuersArgs are the arguments for list_lei_issuers (none).
-type ListLEIIssuersArgs struct{}
+// ListLEIIssuersArgs are the arguments for list_lei_issuers.
+type ListLEIIssuersArgs struct {
+	Limit int `json:"limit,omitempty" jsonschema:"Max issuers to return, 1-1000 (default 100). This tool does not page; raise limit for more"`
+}
 
 // GetReportingExceptionsArgs are the arguments for get_reporting_exceptions.
 type GetReportingExceptionsArgs struct {
@@ -119,14 +121,14 @@ type SearchEntityResult struct {
 	HasMore    *bool          `json:"hasMore,omitempty"`
 }
 
-// IDSearchResult is the result of search_by_bic and search_by_isin. The full
-// LEI records are returned (not the trimmed SimpleRecord), matching the prior
-// behaviour of these two tools.
+// IDSearchResult is the result of search_by_bic and search_by_isin. Records are
+// projected to the trimmed SimpleRecord shape (HG-2 cost-lens) and surfaced
+// under "results", matching search_entity rather than dumping raw LEI records.
 type IDSearchResult struct {
-	Found   bool              `json:"found"`
-	Count   int               `json:"count"`
-	Records []gleif.LEIRecord `json:"records"`
-	Message string            `json:"message,omitempty"`
+	Found   bool           `json:"found"`
+	Count   int            `json:"count"`
+	Results []SimpleRecord `json:"results"`
+	Message string         `json:"message,omitempty"`
 }
 
 // CountryRecord is the trimmed entity shape used by search_by_country (four
@@ -160,8 +162,10 @@ type AutocompleteToolResult struct {
 
 // IssuersResult is the result of list_lei_issuers.
 type IssuersResult struct {
-	Count   int               `json:"count"`
-	Issuers []gleif.LEIIssuer `json:"issuers"`
+	Count     int               `json:"count"`
+	Total     int               `json:"total"`
+	Issuers   []gleif.LEIIssuer `json:"issuers"`
+	Truncated bool              `json:"truncated,omitempty"`
 }
 
 // ReportingExceptionsResult is the result of get_reporting_exceptions.

--- a/tools/handlers.go
+++ b/tools/handlers.go
@@ -217,14 +217,18 @@ func buildIDSearchResult(records []gleif.LEIRecord, emptyMessage string) IDSearc
 		return IDSearchResult{
 			Found:   false,
 			Count:   0,
-			Records: []gleif.LEIRecord{},
+			Results: []SimpleRecord{},
 			Message: emptyMessage,
 		}
 	}
+	results := make([]SimpleRecord, 0, len(records))
+	for _, rec := range records {
+		results = append(results, simplifyRecord(rec))
+	}
 	return IDSearchResult{
 		Found:   true,
-		Count:   len(records),
-		Records: records,
+		Count:   len(results),
+		Results: results,
 	}
 }
 
@@ -302,14 +306,26 @@ func (r *Registry) handleAutocomplete(ctx context.Context, args AutocompleteArgs
 	}, nil
 }
 
-func (r *Registry) handleListLEIIssuers(ctx context.Context, _ ListLEIIssuersArgs) (IssuersResult, error) {
+func (r *Registry) handleListLEIIssuers(ctx context.Context, args ListLEIIssuersArgs) (IssuersResult, error) {
 	issuers, err := r.client.ListLEIIssuers(ctx)
 	if err != nil {
 		return IssuersResult{}, fmt.Errorf("failed to list LEI issuers: %w", err)
 	}
+	limit := args.Limit
+	if limit < 1 || limit > 1000 {
+		limit = 100
+	}
+	total := len(issuers)
+	truncated := false
+	if total > limit {
+		issuers = issuers[:limit]
+		truncated = true
+	}
 	return IssuersResult{
-		Count:   len(issuers),
-		Issuers: issuers,
+		Count:     len(issuers),
+		Total:     total,
+		Issuers:   issuers,
+		Truncated: truncated,
 	}, nil
 }
 

--- a/tools/handlers_lookup_test.go
+++ b/tools/handlers_lookup_test.go
@@ -127,6 +127,38 @@ func TestHandleListLEIIssuers(t *testing.T) {
 			t.Errorf("Expected count=1, got %d", result.Count)
 		}
 	})
+
+	t.Run("caps to limit", func(t *testing.T) {
+		ts := newTestServer()
+		defer ts.Close()
+
+		ts.mux.HandleFunc("/lei-issuers", func(w http.ResponseWriter, _ *http.Request) {
+			resp := gleif.APIResponse[gleif.LEIIssuer]{
+				Data: []gleif.DataItem[gleif.LEIIssuer]{
+					{ID: "A", Type: "lei-issuers", Attributes: gleif.LEIIssuer{Name: "Issuer A", Country: "DE"}},
+					{ID: "B", Type: "lei-issuers", Attributes: gleif.LEIIssuer{Name: "Issuer B", Country: "FR"}},
+					{ID: "C", Type: "lei-issuers", Attributes: gleif.LEIIssuer{Name: "Issuer C", Country: "US"}},
+				},
+			}
+			w.Header().Set("Content-Type", "application/vnd.api+json")
+			_ = json.NewEncoder(w).Encode(resp)
+		})
+
+		registry := newTestRegistry(ts.URL())
+		result, err := registry.handleListLEIIssuers(context.Background(), ListLEIIssuersArgs{Limit: 2})
+		if err != nil {
+			t.Fatalf("handleListLEIIssuers returned error: %v", err)
+		}
+		if result.Count != 2 {
+			t.Errorf("expected capped count=2, got %d", result.Count)
+		}
+		if result.Total != 3 {
+			t.Errorf("expected total=3, got %d", result.Total)
+		}
+		if !result.Truncated {
+			t.Error("expected truncated=true")
+		}
+	})
 }
 
 // TestHandleGetReportingExceptions tests the get_reporting_exceptions handler.

--- a/tools/handlers_search_test.go
+++ b/tools/handlers_search_test.go
@@ -97,6 +97,13 @@ func TestHandleSearchByBIC(t *testing.T) {
 		if !result.Found {
 			t.Error("Expected found=true")
 		}
+		// HG-2: records are projected to the trimmed SimpleRecord shape.
+		if len(result.Results) != 1 {
+			t.Fatalf("expected 1 projected result, got %d", len(result.Results))
+		}
+		if result.Results[0].LegalName != "Deutsche Bank AG" {
+			t.Errorf("expected projected legalName, got %q", result.Results[0].LegalName)
+		}
 	})
 
 	t.Run("no results", func(t *testing.T) {
@@ -117,8 +124,8 @@ func TestHandleSearchByBIC(t *testing.T) {
 		if result.Found {
 			t.Error("Expected found=false")
 		}
-		if result.Records == nil {
-			t.Error("Expected non-nil (empty) records slice on no-results")
+		if result.Results == nil {
+			t.Error("Expected non-nil (empty) results slice on no-results")
 		}
 	})
 


### PR DESCRIPTION
HG-2 signal-density / cost-lens fix. Caps `list_lei_issuers` (default 100) and routes `search_by_bic`/`search_by_isin` through the existing `simplifyRecord` projection (output key `records`→`results` for parity with `search_entity`). Adds cap + projection tests; no existing assertions break.

Refs claude-code-config-uw6i.

🤖 Generated with [Claude Code](https://claude.com/claude-code)